### PR TITLE
Add scripts to create a junction to 'assets' in each target language directory for Linux and Windows

### DIFF
--- a/assets_targets
+++ b/assets_targets
@@ -1,0 +1,10 @@
+cpp
+csharp
+flutter
+go
+java
+nodejs
+py
+rust
+swift
+web

--- a/mk_assets_links.bat
+++ b/mk_assets_links.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal enabledelayedexpansion
+
+
+set ASSETS_DIRNAME=assets
+set TARGETS_FILE=assets_targets
+
+
+if not exist "%ASSETS_DIRNAME%" (
+    mkdir "%ASSETS_DIRNAME%"
+)
+
+for /f "usebackq delims=" %%F in ("%TARGETS_FILE%") do (
+    if exist "%%F\assets" (
+        del /f /q "%%F\%ASSETS_DIRNAME%"
+    )
+    mklink /J "%%F\%ASSETS_DIRNAME%" "%ASSETS_DIRNAME%"
+)
+
+endlocal

--- a/mk_assets_links.sh
+++ b/mk_assets_links.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+
+ASSETS_DIRNAME="assets"
+TARGETS_FILE="assets_targets"
+
+
+[ -d "$ASSETS_DIRNAME" ] || mkdir "$ASSETS_DIRNAME"
+
+while IFS= read -r F || [ -n "$F" ]; do
+    if [ -d "$F/assets" ]; then
+        rm -rf "$F/$ASSETS_DIRNAME"
+    fi
+    ln -s "../$ASSETS_DIRNAME" "$F/$ASSETS_DIRNAME"
+done < "$TARGETS_FILE"


### PR DESCRIPTION
By default each target directory contains a junction to 'assets' that only works on Linux. This commit adds a script to create the junctions for Windows users too.