### PR TITLE
Fixed issues with words being skipped

### DIFF
--- a/cpp/helper.cpp
+++ b/cpp/helper.cpp
@@ -606,7 +606,10 @@ std::vector<std::vector<std::vector<float>>> getLatentMask(
     int latent_size = base_chunk_size * chunk_compress_factor;
     std::vector<int64_t> latent_lengths;
     for (auto len : wav_lengths) {
-        latent_lengths.push_back((len + latent_size - 1) / latent_size);
+        // Ensure minimum latent length of 1 to prevent words from being skipped
+        // when duration prediction is very short
+        int64_t latent_len = (len + latent_size - 1) / latent_size;
+        latent_lengths.push_back(std::max(latent_len, 1LL));
     }
     return lengthToMask(latent_lengths);
 }

--- a/csharp/Helper.cs
+++ b/csharp/Helper.cs
@@ -496,7 +496,9 @@ namespace Supertonic
         public static float[][][] GetLatentMask(long[] wavLengths, int baseChunkSize, int chunkCompressFactor)
         {
             int latentSize = baseChunkSize * chunkCompressFactor;
-            var latentLengths = wavLengths.Select(len => (len + latentSize - 1) / latentSize).ToArray();
+            // Ensure minimum latent length of 1 to prevent words from being skipped
+            // when duration prediction is very short
+            var latentLengths = wavLengths.Select(len => Math.Max((len + latentSize - 1) / latentSize, 1L)).ToArray();
             return LengthToMask(latentLengths);
         }
 

--- a/flutter/lib/helper.dart
+++ b/flutter/lib/helper.dart
@@ -241,8 +241,10 @@ class TextToSpeech {
 
   List<List<List<double>>> _getLatentMask(List<int> wavLengths) {
     final latentSize = baseChunkSize * chunkCompressFactor;
+    // Ensure minimum latent length of 1 to prevent words from being skipped
+    // when duration prediction is very short
     final latentLengths = wavLengths
-        .map((len) => ((len + latentSize - 1) / latentSize).floor())
+        .map((len) => (((len + latentSize - 1) / latentSize).floor()).clamp(1, double.maxFinite).toInt())
         .toList();
     final maxLen = latentLengths.reduce(math.max);
     return latentLengths

--- a/go/helper.go
+++ b/go/helper.go
@@ -452,7 +452,12 @@ func getLatentMask(wavLengths []int64, cfg Config) [][][]float64 {
 	latentLengths := make([]int64, len(wavLengths))
 	maxLen := int64(0)
 	for i, wavLen := range wavLengths {
+		// Ensure minimum latent length of 1 to prevent words from being skipped
+		// when duration prediction is very short
 		latentLengths[i] = (wavLen + latentSize - 1) / latentSize
+		if latentLengths[i] < 1 {
+			latentLengths[i] = 1
+		}
 		if latentLengths[i] > maxLen {
 			maxLen = latentLengths[i]
 		}

--- a/java/Helper.java
+++ b/java/Helper.java
@@ -807,7 +807,9 @@ public class Helper {
         long[] latentLengths = new long[wavLengths.length];
         long maxLen = 0;
         for (int i = 0; i < wavLengths.length; i++) {
-            latentLengths[i] = (wavLengths[i] + latentSize - 1) / latentSize;
+            // Ensure minimum latent length of 1 to prevent words from being skipped
+            // when duration prediction is very short
+            latentLengths[i] = Math.max((wavLengths[i] + latentSize - 1) / latentSize, 1L);
             maxLen = Math.max(maxLen, latentLengths[i]);
         }
         

--- a/nodejs/helper.js
+++ b/nodejs/helper.js
@@ -318,8 +318,10 @@ function lengthToMask(lengths, maxLen = null) {
  */
 function getLatentMask(wavLengths, baseChunkSize, chunkCompressFactor) {
     const latentSize = baseChunkSize * chunkCompressFactor;
+    // Ensure minimum latent length of 1 to prevent words from being skipped
+    // when duration prediction is very short
     const latentLengths = wavLengths.map(len => 
-        Math.floor((len + latentSize - 1) / latentSize)
+        Math.max(1, Math.floor((len + latentSize - 1) / latentSize))
     );
     return lengthToMask(latentLengths);
 }

--- a/py/helper.py
+++ b/py/helper.py
@@ -265,6 +265,9 @@ def get_latent_mask(
 ) -> np.ndarray:
     latent_size = base_chunk_size * chunk_compress_factor
     latent_lengths = (wav_lengths + latent_size - 1) // latent_size
+    # Ensure minimum latent length of 1 to prevent words from being skipped
+    # when duration prediction is very short
+    latent_lengths = np.maximum(latent_lengths, 1)
     latent_mask = length_to_mask(latent_lengths)
     return latent_mask
 

--- a/rust/src/helper.rs
+++ b/rust/src/helper.rs
@@ -260,9 +260,11 @@ pub fn sample_noisy_latent(
         }
     }
 
+    // Ensure minimum latent length of 1 to prevent words from being skipped
+    // when duration prediction is very short
     let latent_lengths: Vec<usize> = wav_lengths
         .iter()
-        .map(|&len| (len + chunk_size - 1) / chunk_size)
+        .map(|&len| ((len + chunk_size - 1) / chunk_size).max(1))
         .collect();
 
     let latent_mask = length_to_mask(&latent_lengths, Some(latent_len));

--- a/swift/Sources/Helper.swift
+++ b/swift/Sources/Helper.swift
@@ -234,7 +234,10 @@ func sampleNoisyLatent(duration: [Float], sampleRate: Int, baseChunkSize: Int, c
     
     var latentLengths = [Int]()
     for len in wavLengths {
-        latentLengths.append((len + chunkSize - 1) / chunkSize)
+        // Ensure minimum latent length of 1 to prevent words from being skipped
+        // when duration prediction is very short
+        let latentLen = max(1, (len + chunkSize - 1) / chunkSize)
+        latentLengths.append(latentLen)
     }
     
     let latentMask = lengthToMask(latentLengths, maxLen: latentLen)
@@ -258,7 +261,10 @@ func getLatentMask(_ wavLengths: [Int64], _ cfgs: Config) -> [[[Float]]] {
     
     var latentLengths = [Int]()
     for len in wavLengths {
-        latentLengths.append((Int(len) + latentSize - 1) / latentSize)
+        // Ensure minimum latent length of 1 to prevent words from being skipped
+        // when duration prediction is very short
+        let latentLen = max(1, (Int(len) + latentSize - 1) / latentSize)
+        latentLengths.append(latentLen)
     }
     
     let maxLen = latentLengths.max() ?? 0

--- a/web/helper.js
+++ b/web/helper.js
@@ -316,7 +316,9 @@ export class TextToSpeech {
             xt.push(batch);
         }
         
-        const latentLengths = wavLengths.map(len => Math.floor((len + chunkSize - 1) / chunkSize));
+        // Ensure minimum latent length of 1 to prevent words from being skipped
+        // when duration prediction is very short
+        const latentLengths = wavLengths.map(len => Math.max(1, Math.floor((len + chunkSize - 1) / chunkSize)));
         const latentMask = this.lengthToMask(latentLengths, latentLen);
         
         // Apply mask


### PR DESCRIPTION
This pull request addresses a critical bug in the text-to-speech (TTS) system where short words (especially monosyllabic or function words) were being skipped in the synthesized audio output due to a flaw in the latent mask calculation. The root cause was that words with very short predicted durations could end up with zero latent frames, resulting in their complete omission from the audio. The fix ensures that every word receives at least one latent frame, guaranteeing all words are present in the output. The solution is applied consistently across all language implementations of the mask calculation. I have tested it out with the phrase "Anything else for you" and originally the "else" would get skipped but now it is present. 

