### PR TITLE
Fix iOS audio playback by configuring AVAudioSession

### DIFF
--- a/ios/ExampleiOSApp/AudioPlayer.swift
+++ b/ios/ExampleiOSApp/AudioPlayer.swift
@@ -8,6 +8,11 @@ final class AudioPlayer: NSObject, AVAudioPlayerDelegate {
     func play(url: URL, onFinish: (() -> Void)? = nil) {
         self.onFinish = onFinish
         do {
+            // Configure audio session for playback
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .default)
+            try audioSession.setActive(true)
+
             let data = try Data(contentsOf: url)
             let player = try AVAudioPlayer(data: data)
             player.delegate = self


### PR DESCRIPTION
   The iOS example app was not playing audio because the AVAudioSession
   was not properly configured. This fix adds the necessary audio session
   setup to enable playback even when the device is in silent mode.

   Changes:
   - Configure AVAudioSession with .playback category
   - Activate audio session before playing audio