### PR TITLE
feat: implement multithreaded WASM support, WebGPU fallback, and asse…

### DIFF
--- a/web/helper.js
+++ b/web/helper.js
@@ -426,47 +426,94 @@ export async function loadTextProcessor(onnxDir) {
 }
 
 /**
- * Load ONNX model
+ * Load ONNX model with optional progress reporting.
+ *
+ * We fetch the bytes ourselves so we can show download progress and so the
+ * browser cache keeps a single copy regardless of the execution provider
+ * chosen by ORT (avoiding a 2x download on WebGPU->WASM fallback).
  */
-export async function loadOnnx(onnxPath, options) {
-    const session = await ort.InferenceSession.create(onnxPath, options);
-    return session;
+export async function loadOnnx(onnxPath, options, onBytes = null) {
+    const response = await fetch(onnxPath, { cache: 'force-cache' });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${onnxPath}: ${response.status}`);
+    }
+
+    const totalHeader = response.headers.get('content-length');
+    const total = totalHeader ? parseInt(totalHeader, 10) : 0;
+
+    let buffer;
+    if (onBytes && response.body) {
+        const reader = response.body.getReader();
+        const chunks = [];
+        let received = 0;
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            chunks.push(value);
+            received += value.length;
+            onBytes(received, total);
+        }
+        const merged = new Uint8Array(received);
+        let offset = 0;
+        for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+        }
+        buffer = merged.buffer;
+    } else {
+        buffer = await response.arrayBuffer();
+    }
+
+    return await ort.InferenceSession.create(buffer, options);
 }
 
 /**
- * Load all TTS components
+ * Load all TTS components.
+ *
+ * Models are downloaded in parallel and ORT is given the full provider list,
+ * so on WebGPU failure it falls back internally without re-fetching weights.
  */
 export async function loadTextToSpeech(onnxDir, sessionOptions = {}, progressCallback = null) {
-    console.log('Using WebAssembly/WebGPU for inference');
-    
     const cfgs = await loadCfgs(onnxDir);
-    
-    const dpPath = `${onnxDir}/duration_predictor.onnx`;
-    const textEncPath = `${onnxDir}/text_encoder.onnx`;
-    const vectorEstPath = `${onnxDir}/vector_estimator.onnx`;
-    const vocoderPath = `${onnxDir}/vocoder.onnx`;
-    
+
     const modelPaths = [
-        { name: 'Duration Predictor', path: dpPath },
-        { name: 'Text Encoder', path: textEncPath },
-        { name: 'Vector Estimator', path: vectorEstPath },
-        { name: 'Vocoder', path: vocoderPath }
+        { name: 'Duration Predictor', path: `${onnxDir}/duration_predictor.onnx` },
+        { name: 'Text Encoder', path: `${onnxDir}/text_encoder.onnx` },
+        { name: 'Vector Estimator', path: `${onnxDir}/vector_estimator.onnx` },
+        { name: 'Vocoder', path: `${onnxDir}/vocoder.onnx` }
     ];
-    
-    const sessions = [];
-    for (let i = 0; i < modelPaths.length; i++) {
-        if (progressCallback) {
-            progressCallback(modelPaths[i].name, i + 1, modelPaths.length);
-        }
-        const session = await loadOnnx(modelPaths[i].path, sessionOptions);
-        sessions.push(session);
-    }
-    
+
+    const total = modelPaths.length;
+    let completed = 0;
+    const progress = new Array(total).fill({ received: 0, total: 0 });
+
+    const reportProgress = () => {
+        if (!progressCallback) return;
+        const totalBytes = progress.reduce((s, p) => s + (p.total || 0), 0);
+        const receivedBytes = progress.reduce((s, p) => s + p.received, 0);
+        const mb = (b) => (b / (1024 * 1024)).toFixed(1);
+        const label = totalBytes > 0
+            ? `${mb(receivedBytes)} / ${mb(totalBytes)} MB`
+            : `${mb(receivedBytes)} MB`;
+        progressCallback(label, completed, total);
+    };
+
+    const sessions = await Promise.all(modelPaths.map((m, i) =>
+        loadOnnx(m.path, sessionOptions, (received, t) => {
+            progress[i] = { received, total: t };
+            reportProgress();
+        }).then((session) => {
+            completed += 1;
+            reportProgress();
+            return session;
+        })
+    ));
+
     const [dpOrt, textEncOrt, vectorEstOrt, vocoderOrt] = sessions;
-    
+
     const textProcessor = await loadTextProcessor(onnxDir);
     const textToSpeech = new TextToSpeech(cfgs, textProcessor, dpOrt, textEncOrt, vectorEstOrt, vocoderOrt);
-    
+
     return { textToSpeech, cfgs };
 }
 

--- a/web/main.js
+++ b/web/main.js
@@ -1,8 +1,21 @@
+import * as ort from 'onnxruntime-web';
 import {
     loadTextToSpeech,
     loadVoiceStyle,
     writeWavFile
 } from './helper.js';
+
+// Configure ORT runtime once, before any session is created.
+// SIMD is always on in modern browsers; threads need cross-origin isolation
+// (see vite.config.js, which sets COOP/COEP headers in dev).
+const cpuThreads = (typeof navigator !== 'undefined' && navigator.hardwareConcurrency)
+    ? Math.min(navigator.hardwareConcurrency, 4)
+    : 1;
+const crossOriginIsolated = (typeof self !== 'undefined' && self.crossOriginIsolated) === true;
+ort.env.wasm.simd = true;
+ort.env.wasm.numThreads = crossOriginIsolated ? cpuThreads : 1;
+ort.env.wasm.proxy = false;
+ort.env.logLevel = 'warning';
 
 // Configuration
 const DEFAULT_VOICE_STYLE_PATH = 'assets/voice_styles/M1.json';
@@ -68,54 +81,53 @@ async function loadStyleFromJSON(stylePath) {
     }
 }
 
+// Detect WebGPU once so ORT can fall back to WASM per-op without re-downloading.
+async function detectWebGPU() {
+    if (typeof navigator === 'undefined' || !navigator.gpu) return false;
+    try {
+        const adapter = await navigator.gpu.requestAdapter();
+        return !!adapter;
+    } catch {
+        return false;
+    }
+}
+
 // Load models on page load
 async function initializeModels() {
     try {
         showStatus('ℹ️ <strong>Loading configuration...</strong>');
-        
+
         const basePath = 'assets/onnx';
-        
-        // Try WebGPU first, fallback to WASM
-        let executionProvider = 'wasm';
-        try {
-            const result = await loadTextToSpeech(basePath, {
-                executionProviders: ['webgpu'],
-                graphOptimizationLevel: 'all'
-            }, (modelName, current, total) => {
-                showStatus(`ℹ️ <strong>Loading ONNX models (${current}/${total}):</strong> ${modelName}...`);
-            });
-            
-            textToSpeech = result.textToSpeech;
-            cfgs = result.cfgs;
-            
-            executionProvider = 'webgpu';
+
+        const hasWebGPU = await detectWebGPU();
+        const executionProviders = hasWebGPU ? ['webgpu', 'wasm'] : ['wasm'];
+        const executionProvider = hasWebGPU ? 'webgpu' : 'wasm';
+
+        const result = await loadTextToSpeech(basePath, {
+            executionProviders,
+            graphOptimizationLevel: 'all'
+        }, (label, current, total) => {
+            showStatus(`ℹ️ <strong>Loading ONNX models (${current}/${total}):</strong> ${label}`);
+        });
+
+        textToSpeech = result.textToSpeech;
+        cfgs = result.cfgs;
+
+        if (hasWebGPU) {
             backendBadge.textContent = 'WebGPU';
             backendBadge.style.background = '#4caf50';
-        } catch (webgpuError) {
-            console.log('WebGPU not available, falling back to WebAssembly');
-            
-            const result = await loadTextToSpeech(basePath, {
-                executionProviders: ['wasm'],
-                graphOptimizationLevel: 'all'
-            }, (modelName, current, total) => {
-                showStatus(`ℹ️ <strong>Loading ONNX models (${current}/${total}):</strong> ${modelName}...`);
-            });
-            
-            textToSpeech = result.textToSpeech;
-            cfgs = result.cfgs;
         }
-        
+
         showStatus('ℹ️ <strong>Loading default voice style...</strong>');
-        
-        // Load default voice style
+
         currentStyle = await loadStyleFromJSON(currentStylePath);
         voiceStyleInfo.textContent = `${getFilenameFromPath(currentStylePath)} (default)`;
-        
+
         showStatus(`✅ <strong>Models loaded!</strong> Using ${executionProvider.toUpperCase()}. You can now generate speech.`, 'success');
         showBackendBadge();
-        
+
         generateBtn.disabled = false;
-        
+
     } catch (error) {
         console.error('Error loading models:', error);
         showStatus(`❌ <strong>Error loading models:</strong> ${error.message}`, 'error');

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,6 +6,32 @@ import { defineConfig } from 'vite';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootAssetsDir = path.resolve(__dirname, '../assets');
 
+const MIME = {
+  '.onnx': 'application/octet-stream',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.bin': 'application/octet-stream'
+};
+
+function parseRange(header, size) {
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header);
+  if (!m) return null;
+  let start = m[1] === '' ? null : parseInt(m[1], 10);
+  let end = m[2] === '' ? null : parseInt(m[2], 10);
+  if (start === null) {
+    if (end === null) return null;
+    start = Math.max(0, size - end);
+    end = size - 1;
+  } else if (end === null) {
+    end = size - 1;
+  }
+  if (isNaN(start) || isNaN(end) || start > end || end >= size) return null;
+  return { start, end };
+}
+
+// Serves the shared `../assets` directory with proper headers so the browser
+// can cache the ~400 MB of ONNX weights, show download progress (via
+// Content-Length), and resume via Range requests.
 function serveRootAssets() {
   return {
     name: 'serve-root-assets',
@@ -25,14 +51,65 @@ function serveRootAssets() {
           return;
         }
 
+        const ext = path.extname(filePath).toLowerCase();
+        const mime = MIME[ext] || 'application/octet-stream';
+        const etag = `W/"${stat.size.toString(16)}-${stat.mtimeMs.toString(16)}"`;
+
+        if (req.headers['if-none-match'] === etag) {
+          res.statusCode = 304;
+          res.end();
+          return;
+        }
+
+        res.setHeader('Content-Type', mime);
+        res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+        res.setHeader('ETag', etag);
+        res.setHeader('Accept-Ranges', 'bytes');
+
+        const range = req.headers.range ? parseRange(req.headers.range, stat.size) : null;
+        if (range) {
+          const { start, end } = range;
+          res.statusCode = 206;
+          res.setHeader('Content-Range', `bytes ${start}-${end}/${stat.size}`);
+          res.setHeader('Content-Length', String(end - start + 1));
+          createReadStream(filePath, { start, end }).pipe(res);
+          return;
+        }
+
+        res.setHeader('Content-Length', String(stat.size));
+        if (req.method === 'HEAD') {
+          res.end();
+          return;
+        }
         createReadStream(filePath).pipe(res);
       });
     }
   };
 }
 
+// Enables SharedArrayBuffer so onnxruntime-web can use multi-threaded WASM.
+function crossOriginIsolation() {
+  return {
+    name: 'cross-origin-isolation',
+    configureServer(server) {
+      server.middlewares.use((_req, res, next) => {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+        next();
+      });
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use((_req, res, next) => {
+        res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+        res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+        next();
+      });
+    }
+  };
+}
+
 export default defineConfig({
-  plugins: [serveRootAssets()],
+  plugins: [crossOriginIsolation(), serveRootAssets()],
   server: {
     port: 3000,
     open: true


### PR DESCRIPTION
## Summary

The web demo took up to 10 minutes to become usable because ~400 MB of ONNX
weights were being downloaded inefficiently. This PR rewires the dev server,
loader, and ONNX Runtime config so the first load is several times faster and
subsequent loads are near-instant.

## What was wrong

- **Sequential downloads.** The 4 ONNX models (~400 MB total) were fetched one
  after another in a `for` loop.
- **Double-download on WebGPU fallback.** If WebGPU init failed, the code
  called the loader a second time with `executionProviders: ['wasm']`,
  re-downloading every model — ~800 MB worst case.
- **No browser caching.** The dev-server middleware piped files with no
  `Content-Type`, `Content-Length`, `ETag`, or `Cache-Control`, so every
  refresh re-fetched the full 400 MB and the UI could not show real progress.
- **WASM threads disabled.** No COOP/COEP headers meant `SharedArrayBuffer`
  was unavailable, so onnxruntime-web ran single-threaded.

## Changes

### `web/helper.js`
- `loadOnnx` now fetches the model itself as an `ArrayBuffer` (with streaming
  byte-level progress and `cache: 'force-cache'`) and passes the buffer to
  `InferenceSession.create`. ORT can switch execution providers without
  re-downloading the weights.
- `loadTextToSpeech` downloads all 4 models in parallel via `Promise.all`
  instead of sequentially.
- Progress callback now reports aggregated MB downloaded / total MB.

### `web/main.js`
- Detect WebGPU once with `navigator.gpu.requestAdapter()`, then call the
  loader **once** with `executionProviders: ['webgpu', 'wasm']`. ORT falls
  back per-op internally — no second download.
- Configure `ort.env.wasm` up front: SIMD on, `numThreads` set from
  `navigator.hardwareConcurrency` (capped at 4) when the page is
  cross-origin isolated.

### `web/vite.config.js`
- Static-asset middleware now sets `Content-Type`, `Content-Length`, `ETag`,
  `Accept-Ranges`, and `Cache-Control: public, max-age=31536000, immutable`,
  with `304 Not Modified` short-circuit and HTTP `Range` support.
- New COOP/COEP plugin sets `Cross-Origin-Opener-Policy: same-origin` and
  `Cross-Origin-Embedder-Policy: require-corp` on all dev/preview responses,
  enabling `SharedArrayBuffer` (required for multi-threaded WASM).

## Test plan

- [ ] `npm run dev` — first load: 4 `.onnx` requests fire in parallel in the
      Network tab; status shows live MB progress.
- [ ] Refresh the page — all 4 models return `304 Not Modified` (or come
      from the disk cache); UI is ready almost immediately.
- [ ] On a machine with WebGPU: backend badge reads `WebGPU`, no second
      download in the Network tab.
- [ ] On a machine without WebGPU: falls back to WASM with a single download.
- [ ] In the console: `self.crossOriginIsolated === true` and
      `ort.env.wasm.numThreads > 1`.
- [ ] Generate speech end-to-end and verify the audio plays.
