### PR TITLE
Initial Version for GPU inference in CPP 

### DIFF
--- a/cpp/example_onnx.cpp
+++ b/cpp/example_onnx.cpp
@@ -71,12 +71,17 @@ int main(int argc, char* argv[]) {
     int bsz = voice_style_paths.size();
     
     // --- 2. Load Text to Speech --- //
+    auto providers = Ort::GetAvailableProviders();
+    bool has_cuda = false | std::find(providers.begin(), providers.end(),
+                            "CUDAExecutionProvider") != providers.end();
+
+    std::cout << "CUDA available: " << std::boolalpha << has_cuda << std::endl;
     Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "TTS");
     Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(
         OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault
     );
     
-    auto text_to_speech = loadTextToSpeech(env, args.onnx_dir, false);
+    auto text_to_speech = loadTextToSpeech(env, args.onnx_dir, has_cuda);
     std::cout << std::endl;
     
     // --- 3. Load Voice Style --- //

--- a/cpp/helper.cpp
+++ b/cpp/helper.cpp
@@ -8,7 +8,10 @@
 #include <regex>
 #include <unordered_map>
 #include <nlohmann/json.hpp>
-
+#include <memory>
+#include <mutex>
+#include <string>
+#include <onnxruntime_cxx_api.h>
 using json = nlohmann::json;
 
 // Available languages for multilingual TTS
@@ -905,15 +908,32 @@ std::unique_ptr<TextToSpeech> loadTextToSpeech(
     const std::string& onnx_dir,
     bool use_gpu
 ) {
-    Ort::SessionOptions opts;
+    Ort::SessionOptions options;
     if (use_gpu) {
-        throw std::runtime_error("GPU mode is not supported yet");
+        std::cout << "Using GPU for inference" << std::endl;
+        options.SetIntraOpNumThreads(1);
+        options.SetInterOpNumThreads(1);
+        options.SetExecutionMode(ORT_SEQUENTIAL);
+        options.SetGraphOptimizationLevel(ORT_ENABLE_BASIC);
+        options.SetLogSeverityLevel(ORT_LOGGING_LEVEL_WARNING);
+        size_t gpu_mem_limit_mb = 2048;      //GPU Mem limit
+        OrtCUDAProviderOptions cuda_options{};
+        memset(&cuda_options, 0, sizeof(cuda_options));
+        cuda_options.device_id                 = 0;
+        cuda_options.cudnn_conv_algo_search    = OrtCudnnConvAlgoSearchHeuristic;
+        cuda_options.gpu_mem_limit             = static_cast<size_t>(gpu_mem_limit_mb) * 1024 * 1024;
+        cuda_options.arena_extend_strategy     = 0; // kSameAsRequested
+        cuda_options.do_copy_in_default_stream = 1;
+
+        options.AppendExecutionProvider_CUDA(cuda_options);
+        options.EnableCpuMemArena();
+        options.EnableMemPattern();
     } else {
         std::cout << "Using CPU for inference" << std::endl;
     }
     
     auto cfgs = loadCfgs(onnx_dir);
-    auto models = loadOnnxAll(env, onnx_dir, opts);
+    auto models = loadOnnxAll(env, onnx_dir, options);
     auto text_processor = loadTextProcessor(onnx_dir);
     
     // Transfer ownership to TextToSpeech (use raw pointers internally)


### PR DESCRIPTION
### Inference Performance Benchmarks

<img width="1177" height="433" alt="cpu_infer" src="https://github.com/user-attachments/assets/f6d03616-ac64-41bf-9ed4-4be58d88c343" />

* **CPU Execution:** Inference time with the **CPUExecutionProvider** is **5507 ms**.

---

<img width="1398" height="815" alt="gpu_infer" src="https://github.com/user-attachments/assets/a035a265-126c-4c4a-8691-a108ed510f60" />

* **GPU Acceleration:** Inference time with the **CUDAExecutionProvider** drops to **1574 ms** (approximately a **3.5x speedup**).

---

<img width="1102" height="264" alt="gpu_use" src="https://github.com/user-attachments/assets/38939eb4-a579-49ef-8852-e77980c20b70" />


### Resource Utilization & Future Optimizations

* **Current Status:** **GPU memory use is high** due to the utilization of the **FP32 model**. 
* **Next Steps:** Resource utilization **can be reduced with FP16 quantization**. More tweaks can be done to achieve lower resource footprint and optimize overall hardware efficiency.
