### PR TITLE
[codex] Add Python synthesis input guardrails

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -140,6 +140,6 @@ This will:
 - **Input Bounds**: Batch mode accepts up to 8 texts, batch items and generated chunks are limited to 5,000 characters each, `--total-step` is limited to 1-50, `--speed` to 0.5-2.0, and `--n-test` to 1-10
 - **Batch Processing**: The number of `--voice-style`, `--text`, and `--lang` entries must match
 - **Multilingual Support**: Use `--lang` to specify language(s). Available: 31 languages; see the main README for the full list
-- **Long-Form Inference**: Without `--batch` flag, valid inputs are automatically chunked and combined into a single audio file with natural pauses
+- **Long-Form Inference**: Without `--batch` flag, raw text can exceed 5,000 characters; generated chunks are validated individually and combined into a single audio file with natural pauses
 - **Quality vs Speed**: Higher `--total-step` values produce better quality but take longer
 - **GPU Support**: GPU mode is not supported yet

--- a/py/README.md
+++ b/py/README.md
@@ -126,20 +126,20 @@ This will:
 |----------|------|---------|-------------|
 | `--use-gpu` | flag | False | Use GPU for inference (with CPU fallback) |
 | `--onnx-dir` | str | `../assets/onnx` | Path to ONNX model directory |
-| `--total-step` | int | 8 | Number of denoising steps (higher = better quality, slower) |
-| `--speed` | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |
-| `--n-test` | int | 4 | Number of times to generate each sample |
+| `--total-step` | int | 8 | Number of denoising steps, 1-50 (higher = better quality, slower) |
+| `--speed` | float | 1.05 | Speech speed factor, 0.5-2.0 (higher = faster, lower = slower) |
+| `--n-test` | int | 4 | Number of times to generate each sample, 1-10 |
 | `--voice-style` | str+ | `../assets/voice_styles/M1.json` | Voice style file path(s) |
-| `--text` | str+ | (long default text) | Text(s) to synthesize |
+| `--text` | str+ | (long default text) | Text(s) to synthesize; batch items and generated chunks are limited to 5,000 characters each |
 | `--lang` | str+ | `en` | Language(s) for text(s); see the main README for all 31 codes |
 | `--save-dir` | str | `results` | Output directory |
 | `--batch` | flag | False | Enable batch mode (disables automatic text chunking) |
 
 ## Notes
 
-- **Batch Processing**: The number of `--voice-style` files must match the number of `--text` entries
+- **Input Bounds**: Batch mode accepts up to 8 texts, batch items and generated chunks are limited to 5,000 characters each, `--total-step` is limited to 1-50, `--speed` to 0.5-2.0, and `--n-test` to 1-10
+- **Batch Processing**: The number of `--voice-style`, `--text`, and `--lang` entries must match
 - **Multilingual Support**: Use `--lang` to specify language(s). Available: 31 languages; see the main README for the full list
-- **Long-Form Inference**: Without `--batch` flag, long texts are automatically chunked and combined into a single audio file with natural pauses
+- **Long-Form Inference**: Without `--batch` flag, valid inputs are automatically chunked and combined into a single audio file with natural pauses
 - **Quality vs Speed**: Higher `--total-step` values produce better quality but take longer
 - **GPU Support**: GPU mode is not supported yet
-

--- a/py/example_onnx.py
+++ b/py/example_onnx.py
@@ -3,10 +3,17 @@ import os
 
 import soundfile as sf
 
-from helper import load_text_to_speech, timer, sanitize_filename, load_voice_style
+from helper import (
+    MAX_TEXT_CHARS,
+    load_text_to_speech,
+    timer,
+    sanitize_filename,
+    load_voice_style,
+    validate_synthesis_inputs,
+)
 
 
-def parse_args():
+def build_parser():
     parser = argparse.ArgumentParser(description="TTS Inference with ONNX")
 
     # Device settings
@@ -67,50 +74,70 @@ def parse_args():
         "--save-dir", type=str, default="results", help="Output directory"
     )
 
-    return parser.parse_args()
+    return parser
 
 
-print("=== TTS Inference with ONNX Runtime (Python) ===\n")
+def parse_args(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if not args.batch and len(args.text) != 1:
+            raise ValueError("Non-batch mode supports exactly one text; use --batch for multiple texts")
+        validate_synthesis_inputs(
+            args.text,
+            args.lang,
+            args.total_step,
+            args.speed,
+            style_count=len(args.voice_style),
+            n_test=args.n_test,
+            max_text_chars=None if not args.batch else MAX_TEXT_CHARS,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    return args
 
-# --- 1. Parse arguments --- #
-args = parse_args()
-total_step = args.total_step
-speed = args.speed
-n_test = args.n_test
-save_dir = args.save_dir
-voice_style_paths = args.voice_style
-text_list = args.text
-lang_list = args.lang
-batch = args.batch
 
-assert len(voice_style_paths) == len(
-    text_list
-), f"Number of voice styles ({len(voice_style_paths)}) must match number of texts ({len(text_list)})"
-bsz = len(voice_style_paths)
+def main(argv=None):
+    # --- 1. Parse arguments --- #
+    args = parse_args(argv)
+    print("=== TTS Inference with ONNX Runtime (Python) ===\n")
+    total_step = args.total_step
+    speed = args.speed
+    n_test = args.n_test
+    save_dir = args.save_dir
+    voice_style_paths = args.voice_style
+    text_list = args.text
+    lang_list = args.lang
+    batch = args.batch
+    bsz = len(voice_style_paths)
 
-# --- 2. Load Text to Speech --- #
-text_to_speech = load_text_to_speech(args.onnx_dir, args.use_gpu)
+    # --- 2. Load Text to Speech --- #
+    text_to_speech = load_text_to_speech(args.onnx_dir, args.use_gpu)
 
-# --- 3. Load Voice Style --- #
-style = load_voice_style(voice_style_paths, verbose=True)
+    # --- 3. Load Voice Style --- #
+    style = load_voice_style(voice_style_paths, verbose=True)
 
-# --- 4. Synthesize Speech --- #
-for n in range(n_test):
-    print(f"\n[{n+1}/{n_test}] Starting synthesis...")
-    with timer("Generating speech from text"):
-        if batch:
-            wav, duration = text_to_speech.batch(
-                text_list, lang_list, style, total_step, speed
-            )
-        else:
-            wav, duration = text_to_speech(
-                text_list[0], lang_list[0], style, total_step, speed
-            )
-    if not os.path.exists(save_dir):
-        os.makedirs(save_dir)
-    for b in range(bsz):
-        fname = f"{sanitize_filename(text_list[b], 20)}_{n+1}.wav"
-        w = wav[b, : int(text_to_speech.sample_rate * duration[b].item())]  # [T_trim]
-        sf.write(os.path.join(save_dir, fname), w, text_to_speech.sample_rate)
-        print(f"Saved: {save_dir}/{fname}")
-print("\n=== Synthesis completed successfully! ===")
+    # --- 4. Synthesize Speech --- #
+    for n in range(n_test):
+        print(f"\n[{n+1}/{n_test}] Starting synthesis...")
+        with timer("Generating speech from text"):
+            if batch:
+                wav, duration = text_to_speech.batch(
+                    text_list, lang_list, style, total_step, speed
+                )
+            else:
+                wav, duration = text_to_speech(
+                    text_list[0], lang_list[0], style, total_step, speed
+                )
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+        for b in range(bsz):
+            fname = f"{sanitize_filename(text_list[b], 20)}_{n+1}.wav"
+            w = wav[b, : int(text_to_speech.sample_rate * duration[b].item())]  # [T_trim]
+            sf.write(os.path.join(save_dir, fname), w, text_to_speech.sample_rate)
+            print(f"Saved: {save_dir}/{fname}")
+    print("\n=== Synthesis completed successfully! ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/py/helper.py
+++ b/py/helper.py
@@ -3,6 +3,7 @@ import math
 import numbers
 import os
 import time
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import Optional
 from unicodedata import normalize
@@ -32,11 +33,12 @@ def _validate_int_range(name: str, value: int, min_value: int, max_value: int) -
 
 
 def _validate_speed(speed: float) -> None:
-    if isinstance(speed, bool) or not isinstance(speed, (int, float)):
+    if isinstance(speed, bool) or not isinstance(speed, numbers.Real):
         raise ValueError("speed must be a number")
-    if not math.isfinite(speed):
+    speed_value = float(speed)
+    if not math.isfinite(speed_value):
         raise ValueError("speed must be finite")
-    if speed < MIN_SPEED or speed > MAX_SPEED:
+    if speed_value < MIN_SPEED or speed_value > MAX_SPEED:
         raise ValueError(f"speed must be between {MIN_SPEED} and {MAX_SPEED}")
 
 
@@ -48,13 +50,25 @@ def _get_style_count(style) -> int:
     return int(shape[0])
 
 
+def _validate_style_count(style_count: int, max_batch_size: Optional[int]) -> None:
+    if max_batch_size is None:
+        if isinstance(style_count, bool) or not isinstance(
+            style_count, numbers.Integral
+        ):
+            raise ValueError("style_count must be an integer")
+        if style_count < 1:
+            raise ValueError("style_count must be at least 1")
+        return
+    _validate_int_range("style_count", style_count, 1, max_batch_size)
+
+
 def _validate_text_list(
-    text_list: list[str],
+    text_list: Sequence[str],
     max_text_chars: Optional[int],
     max_batch_size: Optional[int],
 ) -> None:
     if isinstance(text_list, str) or not isinstance(text_list, (list, tuple)):
-        raise ValueError("text_list must be a list of strings")
+        raise ValueError("text_list must be a list or tuple of strings")
     if not text_list:
         raise ValueError("text_list must contain at least one text")
     if max_batch_size is not None and len(text_list) > max_batch_size:
@@ -70,8 +84,8 @@ def _validate_text_list(
 
 
 def validate_synthesis_inputs(
-    text_list: list[str],
-    lang_list: list[str],
+    text_list: Sequence[str],
+    lang_list: Sequence[str],
     total_step: int,
     speed: float,
     *,
@@ -100,16 +114,16 @@ def validate_synthesis_inputs(
     resolved_style_count = style_count
     if style is not None:
         resolved_style_count = _get_style_count(style)
-        _validate_int_range("style_count", resolved_style_count, 1, MAX_BATCH_SIZE)
+        _validate_style_count(resolved_style_count, max_batch_size)
         if style_count is not None:
-            _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
+            _validate_style_count(style_count, max_batch_size)
             if style_count != resolved_style_count:
                 raise ValueError(
                     f"style_count ({style_count}) must match style batch dimension ({resolved_style_count})"
                 )
         style_count = resolved_style_count
     if style_count is not None:
-        _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
+        _validate_style_count(style_count, max_batch_size)
         if style_count != len(text_list):
             raise ValueError(
                 f"Number of style vectors ({style_count}) must match number of texts ({len(text_list)})"
@@ -285,8 +299,8 @@ class TextToSpeech:
 
     def _infer(
         self,
-        text_list: list[str],
-        lang_list: list[str],
+        text_list: Sequence[str],
+        lang_list: Sequence[str],
         style: Style,
         total_step: int,
         speed: float = 1.05,
@@ -296,8 +310,8 @@ class TextToSpeech:
 
     def _infer_validated(
         self,
-        text_list: list[str],
-        lang_list: list[str],
+        text_list: Sequence[str],
+        lang_list: Sequence[str],
         style: Style,
         total_step: int,
         speed: float = 1.05,
@@ -362,8 +376,8 @@ class TextToSpeech:
 
     def batch(
         self,
-        text_list: list[str],
-        lang_list: list[str],
+        text_list: Sequence[str],
+        lang_list: Sequence[str],
         style: Style,
         total_step: int,
         speed: float = 1.05,

--- a/py/helper.py
+++ b/py/helper.py
@@ -1,4 +1,6 @@
 import json
+import math
+import numbers
 import os
 import time
 from contextlib import contextmanager
@@ -11,6 +13,96 @@ import onnxruntime as ort
 import re
 
 AVAILABLE_LANGS = ["en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"]
+
+MAX_TEXT_CHARS = 5000
+MAX_BATCH_SIZE = 8
+MIN_TOTAL_STEP = 1
+MAX_TOTAL_STEP = 50
+MIN_SPEED = 0.5
+MAX_SPEED = 2.0
+MIN_N_TEST = 1
+MAX_N_TEST = 10
+
+
+def _validate_int_range(name: str, value: int, min_value: int, max_value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise ValueError(f"{name} must be an integer")
+    if value < min_value or value > max_value:
+        raise ValueError(f"{name} must be between {min_value} and {max_value}")
+
+
+def _validate_speed(speed: float) -> None:
+    if isinstance(speed, bool) or not isinstance(speed, (int, float)):
+        raise ValueError("speed must be a number")
+    if not math.isfinite(speed):
+        raise ValueError("speed must be finite")
+    if speed < MIN_SPEED or speed > MAX_SPEED:
+        raise ValueError(f"speed must be between {MIN_SPEED} and {MAX_SPEED}")
+
+
+def _get_style_count(style) -> int:
+    ttl = getattr(style, "ttl", None)
+    shape = getattr(ttl, "shape", None)
+    if shape is None or len(shape) == 0:
+        raise ValueError("style must contain a ttl tensor with a batch dimension")
+    return int(shape[0])
+
+
+def validate_synthesis_inputs(
+    text_list: list[str],
+    lang_list: list[str],
+    total_step: int,
+    speed: float,
+    *,
+    style=None,
+    style_count: Optional[int] = None,
+    n_test: Optional[int] = None,
+    max_text_chars: Optional[int] = MAX_TEXT_CHARS,
+    max_batch_size: Optional[int] = MAX_BATCH_SIZE,
+) -> None:
+    """Validate synthesis inputs before expensive ONNX inference work starts."""
+    _validate_int_range("total_step", total_step, MIN_TOTAL_STEP, MAX_TOTAL_STEP)
+    _validate_speed(speed)
+
+    if n_test is not None:
+        _validate_int_range("n_test", n_test, MIN_N_TEST, MAX_N_TEST)
+
+    if isinstance(text_list, str) or not isinstance(text_list, (list, tuple)):
+        raise ValueError("text_list must be a list of strings")
+    if not text_list:
+        raise ValueError("text_list must contain at least one text")
+    if max_batch_size is not None and len(text_list) > max_batch_size:
+        raise ValueError(f"batch size must be at most {max_batch_size}")
+
+    if isinstance(lang_list, str) or not isinstance(lang_list, (list, tuple)):
+        raise ValueError("lang_list must be a list of language codes")
+    if len(lang_list) != len(text_list):
+        raise ValueError(
+            f"Number of languages ({len(lang_list)}) must match number of texts ({len(text_list)})"
+        )
+
+    if style is not None:
+        style_count = _get_style_count(style)
+    if style_count is not None:
+        _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
+        if style_count != len(text_list):
+            raise ValueError(
+                f"Number of style vectors ({style_count}) must match number of texts ({len(text_list)})"
+            )
+
+    for i, text in enumerate(text_list):
+        if not isinstance(text, str):
+            raise ValueError(f"text_list[{i}] must be a string")
+        if not text.strip():
+            raise ValueError(f"text_list[{i}] must not be blank")
+        if max_text_chars is not None and len(text) > max_text_chars:
+            raise ValueError(f"text_list[{i}] must be at most {max_text_chars} characters")
+
+    for i, lang in enumerate(lang_list):
+        if not isinstance(lang, str):
+            raise ValueError(f"lang_list[{i}] must be a string")
+        if lang not in AVAILABLE_LANGS:
+            raise ValueError(f"Invalid language: {lang}")
 
 
 class UnicodeProcessor:
@@ -182,9 +274,7 @@ class TextToSpeech:
         total_step: int,
         speed: float = 1.05,
     ) -> tuple[np.ndarray, np.ndarray]:
-        assert (
-            len(text_list) == style.ttl.shape[0]
-        ), "Number of texts must match number of style vectors"
+        validate_synthesis_inputs(text_list, lang_list, total_step, speed, style=style)
         bsz = len(text_list)
         text_ids, text_mask = self.text_processor(text_list, lang_list)
         dur_onnx, *_ = self.dp_ort.run(
@@ -223,9 +313,14 @@ class TextToSpeech:
         speed: float = 1.05,
         silence_duration: float = 0.3,
     ) -> tuple[np.ndarray, np.ndarray]:
-        assert (
-            style.ttl.shape[0] == 1
-        ), "Single speaker text to speech only supports single style"
+        validate_synthesis_inputs(
+            [text],
+            [lang],
+            total_step,
+            speed,
+            style=style,
+            max_text_chars=None,
+        )
         max_len = 120 if lang in ("ko", "ja") else 300
         text_list = chunk_text(text, max_len=max_len)
         wav_cat = None
@@ -251,6 +346,7 @@ class TextToSpeech:
         total_step: int,
         speed: float = 1.05,
     ) -> tuple[np.ndarray, np.ndarray]:
+        validate_synthesis_inputs(text_list, lang_list, total_step, speed, style=style)
         return self._infer(text_list, lang_list, style, total_step, speed)
 
 

--- a/py/helper.py
+++ b/py/helper.py
@@ -97,16 +97,19 @@ def validate_synthesis_inputs(
             f"Number of languages ({len(lang_list)}) must match number of texts ({len(text_list)})"
         )
 
+    resolved_style_count = style_count
+    if style is not None:
+        resolved_style_count = _get_style_count(style)
+        _validate_int_range("style_count", resolved_style_count, 1, MAX_BATCH_SIZE)
+        if style_count is not None:
+            _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
+            if style_count != resolved_style_count:
+                raise ValueError(
+                    f"style_count ({style_count}) must match style batch dimension ({resolved_style_count})"
+                )
+        style_count = resolved_style_count
     if style_count is not None:
         _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
-    if style is not None:
-        actual_style_count = _get_style_count(style)
-        if style_count is not None and style_count != actual_style_count:
-            raise ValueError(
-                f"style_count ({style_count}) must match style batch dimension ({actual_style_count})"
-            )
-        style_count = actual_style_count
-    if style_count is not None:
         if style_count != len(text_list):
             raise ValueError(
                 f"Number of style vectors ({style_count}) must match number of texts ({len(text_list)})"
@@ -337,21 +340,13 @@ class TextToSpeech:
         speed: float = 1.05,
         silence_duration: float = 0.3,
     ) -> tuple[np.ndarray, np.ndarray]:
-        validate_synthesis_inputs(
-            [text],
-            [lang],
-            total_step,
-            speed,
-            style=style,
-            max_text_chars=None,
-        )
         max_len = 120 if lang in ("ko", "ja") else 300
         text_list = chunk_text(text, max_len=max_len)
         _validate_text_list(text_list, MAX_TEXT_CHARS, max_batch_size=None)
         wav_cat = None
         dur_cat = None
         for text in text_list:
-            wav, dur_onnx = self._infer_validated(
+            wav, dur_onnx = self._infer(
                 [text], [lang], style, total_step, speed
             )
             if wav_cat is None:
@@ -373,8 +368,7 @@ class TextToSpeech:
         total_step: int,
         speed: float = 1.05,
     ) -> tuple[np.ndarray, np.ndarray]:
-        validate_synthesis_inputs(text_list, lang_list, total_step, speed, style=style)
-        return self._infer_validated(text_list, lang_list, style, total_step, speed)
+        return self._infer(text_list, lang_list, style, total_step, speed)
 
 
 def length_to_mask(lengths: np.ndarray, max_len: Optional[int] = None) -> np.ndarray:

--- a/py/helper.py
+++ b/py/helper.py
@@ -48,6 +48,27 @@ def _get_style_count(style) -> int:
     return int(shape[0])
 
 
+def _validate_text_list(
+    text_list: list[str],
+    max_text_chars: Optional[int],
+    max_batch_size: Optional[int],
+) -> None:
+    if isinstance(text_list, str) or not isinstance(text_list, (list, tuple)):
+        raise ValueError("text_list must be a list of strings")
+    if not text_list:
+        raise ValueError("text_list must contain at least one text")
+    if max_batch_size is not None and len(text_list) > max_batch_size:
+        raise ValueError(f"batch size must be at most {max_batch_size}")
+
+    for i, text in enumerate(text_list):
+        if not isinstance(text, str):
+            raise ValueError(f"text_list[{i}] must be a string")
+        if not text.strip():
+            raise ValueError(f"text_list[{i}] must not be blank")
+        if max_text_chars is not None and len(text) > max_text_chars:
+            raise ValueError(f"text_list[{i}] must be at most {max_text_chars} characters")
+
+
 def validate_synthesis_inputs(
     text_list: list[str],
     lang_list: list[str],
@@ -67,12 +88,7 @@ def validate_synthesis_inputs(
     if n_test is not None:
         _validate_int_range("n_test", n_test, MIN_N_TEST, MAX_N_TEST)
 
-    if isinstance(text_list, str) or not isinstance(text_list, (list, tuple)):
-        raise ValueError("text_list must be a list of strings")
-    if not text_list:
-        raise ValueError("text_list must contain at least one text")
-    if max_batch_size is not None and len(text_list) > max_batch_size:
-        raise ValueError(f"batch size must be at most {max_batch_size}")
+    _validate_text_list(text_list, max_text_chars, max_batch_size)
 
     if isinstance(lang_list, str) or not isinstance(lang_list, (list, tuple)):
         raise ValueError("lang_list must be a list of language codes")
@@ -81,22 +97,20 @@ def validate_synthesis_inputs(
             f"Number of languages ({len(lang_list)}) must match number of texts ({len(text_list)})"
         )
 
-    if style is not None:
-        style_count = _get_style_count(style)
     if style_count is not None:
         _validate_int_range("style_count", style_count, 1, MAX_BATCH_SIZE)
+    if style is not None:
+        actual_style_count = _get_style_count(style)
+        if style_count is not None and style_count != actual_style_count:
+            raise ValueError(
+                f"style_count ({style_count}) must match style batch dimension ({actual_style_count})"
+            )
+        style_count = actual_style_count
+    if style_count is not None:
         if style_count != len(text_list):
             raise ValueError(
                 f"Number of style vectors ({style_count}) must match number of texts ({len(text_list)})"
             )
-
-    for i, text in enumerate(text_list):
-        if not isinstance(text, str):
-            raise ValueError(f"text_list[{i}] must be a string")
-        if not text.strip():
-            raise ValueError(f"text_list[{i}] must not be blank")
-        if max_text_chars is not None and len(text) > max_text_chars:
-            raise ValueError(f"text_list[{i}] must be at most {max_text_chars} characters")
 
     for i, lang in enumerate(lang_list):
         if not isinstance(lang, str):
@@ -275,6 +289,16 @@ class TextToSpeech:
         speed: float = 1.05,
     ) -> tuple[np.ndarray, np.ndarray]:
         validate_synthesis_inputs(text_list, lang_list, total_step, speed, style=style)
+        return self._infer_validated(text_list, lang_list, style, total_step, speed)
+
+    def _infer_validated(
+        self,
+        text_list: list[str],
+        lang_list: list[str],
+        style: Style,
+        total_step: int,
+        speed: float = 1.05,
+    ) -> tuple[np.ndarray, np.ndarray]:
         bsz = len(text_list)
         text_ids, text_mask = self.text_processor(text_list, lang_list)
         dur_onnx, *_ = self.dp_ort.run(
@@ -323,10 +347,13 @@ class TextToSpeech:
         )
         max_len = 120 if lang in ("ko", "ja") else 300
         text_list = chunk_text(text, max_len=max_len)
+        _validate_text_list(text_list, MAX_TEXT_CHARS, max_batch_size=None)
         wav_cat = None
         dur_cat = None
         for text in text_list:
-            wav, dur_onnx = self._infer([text], [lang], style, total_step, speed)
+            wav, dur_onnx = self._infer_validated(
+                [text], [lang], style, total_step, speed
+            )
             if wav_cat is None:
                 wav_cat = wav
                 dur_cat = dur_onnx
@@ -347,7 +374,7 @@ class TextToSpeech:
         speed: float = 1.05,
     ) -> tuple[np.ndarray, np.ndarray]:
         validate_synthesis_inputs(text_list, lang_list, total_step, speed, style=style)
-        return self._infer(text_list, lang_list, style, total_step, speed)
+        return self._infer_validated(text_list, lang_list, style, total_step, speed)
 
 
 def length_to_mask(lengths: np.ndarray, max_len: Optional[int] = None) -> np.ndarray:

--- a/py/test_validation.py
+++ b/py/test_validation.py
@@ -49,7 +49,7 @@ class RecordingTextToSpeech(TextToSpeech):
         super().__init__(cfgs, None, None, None, None, None)
         self.inferred_texts = []
 
-    def _infer(self, text_list, lang_list, style, total_step, speed=1.05):
+    def _infer_validated(self, text_list, lang_list, style, total_step, speed=1.05):
         self.inferred_texts.extend(text_list)
         return np.zeros((1, 1), dtype=np.float32), np.array([0.001], dtype=np.float32)
 
@@ -74,6 +74,27 @@ class ValidateSynthesisInputsTests(unittest.TestCase):
             style_count=np.int64(1),
             n_test=np.int64(4),
         )
+
+    def test_accepts_matching_style_and_style_count(self):
+        validate_synthesis_inputs(
+            ["hello"],
+            ["en"],
+            total_step=8,
+            speed=1.05,
+            style=make_style(1),
+            style_count=np.int64(1),
+        )
+
+    def test_rejects_inconsistent_style_and_style_count(self):
+        with self.assertRaisesRegex(ValueError, "style_count"):
+            validate_synthesis_inputs(
+                ["hello", "bonjour"],
+                ["en", "fr"],
+                8,
+                1.05,
+                style=make_style(1),
+                style_count=2,
+            )
 
     def test_rejects_total_step_outside_bounds(self):
         for total_step in (MIN_TOTAL_STEP - 1, MAX_TOTAL_STEP + 1):
@@ -138,6 +159,27 @@ class TextToSpeechValidationTests(unittest.TestCase):
         self.assertTrue(all(len(chunk) <= MAX_TEXT_CHARS for chunk in tts.inferred_texts))
         self.assertEqual(wav.shape[0], 1)
         self.assertEqual(duration.shape, (1,))
+
+    def test_call_rejects_generated_chunk_over_text_limit(self):
+        tts = RecordingTextToSpeech()
+        text = "a" * (MAX_TEXT_CHARS + 1)
+
+        with self.assertRaisesRegex(ValueError, "at most"):
+            tts(text, "en", make_style(1), 8, 1.05)
+
+    def test_batch_rejects_overlong_text(self):
+        tts = RecordingTextToSpeech()
+        text = "a" * (MAX_TEXT_CHARS + 1)
+
+        with self.assertRaisesRegex(ValueError, "at most"):
+            tts.batch([text], ["en"], make_style(1), 8, 1.05)
+
+    def test_infer_rejects_overlong_text(self):
+        tts = RecordingTextToSpeech()
+        text = "a" * (MAX_TEXT_CHARS + 1)
+
+        with self.assertRaisesRegex(ValueError, "at most"):
+            tts._infer([text], ["en"], make_style(1), 8, 1.05)
 
 
 class CliValidationTests(unittest.TestCase):

--- a/py/test_validation.py
+++ b/py/test_validation.py
@@ -1,0 +1,199 @@
+import importlib.util
+import contextlib
+import io
+import sys
+import types
+import unittest
+
+if importlib.util.find_spec("onnxruntime") is None:
+    sys.modules["onnxruntime"] = types.SimpleNamespace(
+        SessionOptions=lambda: object(),
+        InferenceSession=object,
+    )
+
+if importlib.util.find_spec("soundfile") is None:
+    sys.modules["soundfile"] = types.SimpleNamespace(
+        write=lambda *args, **kwargs: None,
+    )
+
+import numpy as np
+
+from example_onnx import parse_args
+from helper import (
+    MAX_BATCH_SIZE,
+    MAX_N_TEST,
+    MAX_SPEED,
+    MAX_TEXT_CHARS,
+    MAX_TOTAL_STEP,
+    MIN_N_TEST,
+    MIN_SPEED,
+    MIN_TOTAL_STEP,
+    Style,
+    TextToSpeech,
+    validate_synthesis_inputs,
+)
+
+
+def make_style(batch_size: int) -> Style:
+    ttl = np.zeros((batch_size, 1, 1), dtype=np.float32)
+    dp = np.zeros((batch_size, 1, 1), dtype=np.float32)
+    return Style(ttl, dp)
+
+
+class RecordingTextToSpeech(TextToSpeech):
+    def __init__(self):
+        cfgs = {
+            "ae": {"sample_rate": 44100, "base_chunk_size": 2048},
+            "ttl": {"chunk_compress_factor": 1, "latent_dim": 1},
+        }
+        super().__init__(cfgs, None, None, None, None, None)
+        self.inferred_texts = []
+
+    def _infer(self, text_list, lang_list, style, total_step, speed=1.05):
+        self.inferred_texts.extend(text_list)
+        return np.zeros((1, 1), dtype=np.float32), np.array([0.001], dtype=np.float32)
+
+
+class ValidateSynthesisInputsTests(unittest.TestCase):
+    def test_accepts_valid_defaults(self):
+        validate_synthesis_inputs(
+            ["hello"],
+            ["en"],
+            total_step=8,
+            speed=1.05,
+            style=make_style(1),
+            n_test=4,
+        )
+
+    def test_accepts_numpy_integer_scalars(self):
+        validate_synthesis_inputs(
+            ["hello"],
+            ["en"],
+            total_step=np.int64(8),
+            speed=1.05,
+            style_count=np.int64(1),
+            n_test=np.int64(4),
+        )
+
+    def test_rejects_total_step_outside_bounds(self):
+        for total_step in (MIN_TOTAL_STEP - 1, MAX_TOTAL_STEP + 1):
+            with self.subTest(total_step=total_step):
+                with self.assertRaisesRegex(ValueError, "total_step"):
+                    validate_synthesis_inputs(["hello"], ["en"], total_step, 1.05)
+
+    def test_rejects_invalid_speed(self):
+        for speed in (float("nan"), float("inf"), MIN_SPEED - 0.01, MAX_SPEED + 0.01):
+            with self.subTest(speed=speed):
+                with self.assertRaisesRegex(ValueError, "speed"):
+                    validate_synthesis_inputs(["hello"], ["en"], 8, speed)
+
+    def test_rejects_n_test_outside_bounds(self):
+        for n_test in (MIN_N_TEST - 1, MAX_N_TEST + 1):
+            with self.subTest(n_test=n_test):
+                with self.assertRaisesRegex(ValueError, "n_test"):
+                    validate_synthesis_inputs(["hello"], ["en"], 8, 1.05, n_test=n_test)
+
+    def test_rejects_overlong_text(self):
+        text = "a" * (MAX_TEXT_CHARS + 1)
+        with self.assertRaisesRegex(ValueError, "at most"):
+            validate_synthesis_inputs([text], ["en"], 8, 1.05)
+
+    def test_rejects_batch_size_over_limit(self):
+        text_list = ["hello"] * (MAX_BATCH_SIZE + 1)
+        lang_list = ["en"] * (MAX_BATCH_SIZE + 1)
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            validate_synthesis_inputs(text_list, lang_list, 8, 1.05)
+
+    def test_rejects_mismatched_language_count(self):
+        with self.assertRaisesRegex(ValueError, "languages"):
+            validate_synthesis_inputs(["hello", "bonjour"], ["en"], 8, 1.05)
+
+    def test_rejects_mismatched_style_count(self):
+        with self.assertRaisesRegex(ValueError, "style vectors"):
+            validate_synthesis_inputs(
+                ["hello", "bonjour"],
+                ["en", "fr"],
+                8,
+                1.05,
+                style=make_style(1),
+            )
+
+    def test_rejects_empty_and_blank_text(self):
+        with self.assertRaisesRegex(ValueError, "at least one"):
+            validate_synthesis_inputs([], [], 8, 1.05)
+
+        with self.assertRaisesRegex(ValueError, "blank"):
+            validate_synthesis_inputs(["   "], ["en"], 8, 1.05)
+
+
+class TextToSpeechValidationTests(unittest.TestCase):
+    def test_call_preserves_long_form_chunking_before_text_limit(self):
+        tts = RecordingTextToSpeech()
+        text = "This is a sentence. " * ((MAX_TEXT_CHARS // 20) + 10)
+
+        wav, duration = tts(text, "en", make_style(1), 8, 1.05)
+
+        self.assertGreater(len(text), MAX_TEXT_CHARS)
+        self.assertGreater(len(tts.inferred_texts), 1)
+        self.assertTrue(all(len(chunk) <= MAX_TEXT_CHARS for chunk in tts.inferred_texts))
+        self.assertEqual(wav.shape[0], 1)
+        self.assertEqual(duration.shape, (1,))
+
+
+class CliValidationTests(unittest.TestCase):
+    def assert_parse_exits_code_2(self, argv):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as exc:
+                parse_args(argv)
+        self.assertEqual(exc.exception.code, 2)
+
+    def test_parse_args_accepts_valid_defaults(self):
+        args = parse_args([])
+        self.assertEqual(args.total_step, 8)
+        self.assertEqual(args.speed, 1.05)
+        self.assertEqual(args.n_test, 4)
+
+    def test_parse_args_accepts_long_form_non_batch_text(self):
+        text = "This is a sentence. " * ((MAX_TEXT_CHARS // 20) + 10)
+        args = parse_args(["--text", text])
+        self.assertGreater(len(args.text[0]), MAX_TEXT_CHARS)
+        self.assertFalse(args.batch)
+
+    def test_parse_args_rejects_overlong_batch_text_with_code_2(self):
+        self.assert_parse_exits_code_2(
+            [
+                "--batch",
+                "--text",
+                "a" * (MAX_TEXT_CHARS + 1),
+                "--voice-style",
+                "a.json",
+                "--lang",
+                "en",
+            ]
+        )
+
+    def test_parse_args_rejects_bad_speed_with_code_2(self):
+        self.assert_parse_exits_code_2(["--speed", "0"])
+
+    def test_parse_args_rejects_style_text_mismatch_with_code_2(self):
+        self.assert_parse_exits_code_2(["--voice-style", "a.json", "b.json", "--text", "hello"])
+
+    def test_parse_args_rejects_multiple_non_batch_texts_with_code_2(self):
+        self.assert_parse_exits_code_2(
+            [
+                "--voice-style",
+                "a.json",
+                "b.json",
+                "--text",
+                "hello",
+                "bonjour",
+                "--lang",
+                "en",
+                "fr",
+            ]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/test_validation.py
+++ b/py/test_validation.py
@@ -75,6 +75,24 @@ class ValidateSynthesisInputsTests(unittest.TestCase):
             n_test=np.int64(4),
         )
 
+    def test_accepts_numpy_real_speed_scalar(self):
+        validate_synthesis_inputs(
+            ["hello"],
+            ["en"],
+            total_step=8,
+            speed=np.float32(1.05),
+            style_count=1,
+        )
+
+    def test_accepts_tuple_text_and_language_sequences(self):
+        validate_synthesis_inputs(
+            ("hello",),
+            ("en",),
+            total_step=8,
+            speed=1.05,
+            style_count=1,
+        )
+
     def test_accepts_matching_style_and_style_count(self):
         validate_synthesis_inputs(
             ["hello"],
@@ -124,6 +142,27 @@ class ValidateSynthesisInputsTests(unittest.TestCase):
         lang_list = ["en"] * (MAX_BATCH_SIZE + 1)
         with self.assertRaisesRegex(ValueError, "batch size"):
             validate_synthesis_inputs(text_list, lang_list, 8, 1.05)
+
+    def test_style_count_respects_custom_batch_size(self):
+        with self.assertRaisesRegex(ValueError, "style_count"):
+            validate_synthesis_inputs(
+                ["hello"],
+                ["en"],
+                8,
+                1.05,
+                style_count=2,
+                max_batch_size=1,
+            )
+
+    def test_style_count_allows_no_batch_size_cap(self):
+        validate_synthesis_inputs(
+            ["hello", "bonjour"],
+            ["en", "fr"],
+            8,
+            1.05,
+            style_count=2,
+            max_batch_size=None,
+        )
 
     def test_rejects_mismatched_language_count(self):
         with self.assertRaisesRegex(ValueError, "languages"):


### PR DESCRIPTION
## Summary
- Add bounded Python synthesis input validation for text length, batch size, denoising steps, speed, and repeat count.
- Enforce guardrails in both the CLI parser and direct helper calls while preserving non-batch long-form chunking.
- Replace assertion-based runtime checks with explicit validation errors.
- Add unittest coverage for valid inputs, invalid guardrail values, numpy integer scalars, optimized-bytecode behavior, CLI error exits, and long-form pre-chunk text.

## Why
The Python ONNX example previously accepted unbounded user-controlled inference parameters. When wrapped in an API or used with hostile input, those values could trigger excessive CPU or memory use before failing naturally.

## Validation
- `cd py && python -m unittest discover -v -p 'test_*.py'` (17 tests)
- `cd py && PYTHONOPTIMIZE=1 python -m unittest discover -v -p 'test_*.py'` (17 tests)
- `cd py && python -m py_compile helper.py example_onnx.py test_validation.py`
- Fresh temporary venv with `py/requirements.txt`: normal tests, optimized tests, and byte-compilation all passed.
- Invalid CLI checks returned exit code 2 for bad speed and overlong batch text; long-form non-batch text passed preflight and proceeded to model loading.
