### PR TITLE
docs(python): show how to play generated audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ tts.save_audio(wav, "output.wav")
 # sf.write("output.wav", wav.squeeze(), 44100)
 
 print(f"Generated {duration[0]:.2f}s of audio")
+
+# Optional playback:
+# pip install sounddevice
+# import sounddevice as sd
+# sd.play(wav.squeeze().astype("float32"), 44100)
+# sd.wait()
 ```
 
 ## Getting Started

--- a/py/README.md
+++ b/py/README.md
@@ -52,6 +52,27 @@ This will use:
 - Total steps: 8
 - Number of generations: 4
 
+### Optional: Play the generated audio
+
+The example writes `.wav` files into `results/`. To quickly play the most recent result from Python:
+
+```bash
+pip install sounddevice
+
+python - <<'PY'
+from pathlib import Path
+import sounddevice as sd
+import soundfile as sf
+
+wav_path = max(Path("results").glob("*.wav"), key=lambda path: path.stat().st_mtime)
+audio, sample_rate = sf.read(wav_path, dtype="float32")
+
+print(f"Playing {wav_path}")
+sd.play(audio, sample_rate)
+sd.wait()
+PY
+```
+
 ### Example 2: Batch Inference
 Process multiple voice styles and texts at once:
 ```bash


### PR DESCRIPTION
## Summary
- add optional `sounddevice` playback guidance to the main Python quick start
- add a small ONNX example snippet for playing the newest generated `.wav` from `py/results/`

## Why
Issue #101 asks for a demo showing how to play generated audio after synthesis. The current examples show saving `.wav` output, but users still need to know the right array shape / dtype or find the output path themselves before they can hear it.

## Validation
- `python -m py_compile py/example_onnx.py py/example_pypi.py`
- `git diff --check`

Addresses #101.