### PR TITLE
fix: python example crash in non-batch mode, lang validation, and emoji regex perf

### DIFF
--- a/py/example_onnx.py
+++ b/py/example_onnx.py
@@ -86,6 +86,14 @@ batch = args.batch
 assert len(voice_style_paths) == len(
     text_list
 ), f"Number of voice styles ({len(voice_style_paths)}) must match number of texts ({len(text_list)})"
+
+# Validate and broadcast language list
+assert len(lang_list) == len(text_list) or len(lang_list) == 1, (
+    f"Number of languages ({len(lang_list)}) must match number of texts ({len(text_list)}) or be 1"
+)
+if len(lang_list) == 1:
+    lang_list = lang_list * len(text_list)
+
 bsz = len(voice_style_paths)
 
 # --- 2. Load Text to Speech --- #
@@ -108,8 +116,11 @@ for n in range(n_test):
             )
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
-    for b in range(bsz):
-        fname = f"{sanitize_filename(text_list[b], 20)}_{n+1}.wav"
+    # In non-batch mode, wav shape is (1, T) regardless of bsz
+    out_range = bsz if batch else 1
+    for b in range(out_range):
+        text_idx = b if batch else 0
+        fname = f"{sanitize_filename(text_list[text_idx], 20)}_{n+1}.wav"
         w = wav[b, : int(text_to_speech.sample_rate * duration[b].item())]  # [T_trim]
         sf.write(os.path.join(save_dir, fname), w, text_to_speech.sample_rate)
         print(f"Saved: {save_dir}/{fname}")

--- a/py/helper.py
+++ b/py/helper.py
@@ -12,6 +12,23 @@ import re
 
 AVAILABLE_LANGS = ["en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"]
 
+# Pre-compiled emoji pattern (compiled once at module level for performance)
+_EMOJI_PATTERN = re.compile(
+    "[\U0001f600-\U0001f64f"  # emoticons
+    "\U0001f300-\U0001f5ff"  # symbols & pictographs
+    "\U0001f680-\U0001f6ff"  # transport & map symbols
+    "\U0001f700-\U0001f77f"
+    "\U0001f780-\U0001f7ff"
+    "\U0001f800-\U0001f8ff"
+    "\U0001f900-\U0001f9ff"
+    "\U0001fa00-\U0001fa6f"
+    "\U0001fa70-\U0001faff"
+    "\u2600-\u26ff"
+    "\u2700-\u27bf"
+    "\U0001f1e6-\U0001f1ff]+",
+    flags=re.UNICODE,
+)
+
 
 class UnicodeProcessor:
     def __init__(self, unicode_indexer_path: str):
@@ -23,22 +40,7 @@ class UnicodeProcessor:
         text = normalize("NFKD", text)
 
         # Remove emojis (wide Unicode range)
-        emoji_pattern = re.compile(
-            "[\U0001f600-\U0001f64f"  # emoticons
-            "\U0001f300-\U0001f5ff"  # symbols & pictographs
-            "\U0001f680-\U0001f6ff"  # transport & map symbols
-            "\U0001f700-\U0001f77f"
-            "\U0001f780-\U0001f7ff"
-            "\U0001f800-\U0001f8ff"
-            "\U0001f900-\U0001f9ff"
-            "\U0001fa00-\U0001fa6f"
-            "\U0001fa70-\U0001faff"
-            "\u2600-\u26ff"
-            "\u2700-\u27bf"
-            "\U0001f1e6-\U0001f1ff]+",
-            flags=re.UNICODE,
-        )
-        text = emoji_pattern.sub("", text)
+        text = _EMOJI_PATTERN.sub("", text)
 
         # Replace various dashes and symbols
         replacements = {


### PR DESCRIPTION
## Summary

Hey! I was looking through the Python example code and noticed a few bugs that can cause crashes or silent misbehavior. This PR fixes three issues in `py/example_onnx.py` and `py/helper.py`:

### 1. `example_onnx.py` — IndexError in non-batch mode when `bsz > 1`

When a user passes multiple `--voice-style` and `--text` args without `--batch`, the `__call__` method produces `wav` with shape `(1, T)` (since it only processes `text_list[0]`). But the save loop iterates `range(bsz)`, causing `wav[b, :]` to throw an `IndexError` for `b > 0`.

**Fix:** Scope the output loop to `1` in non-batch mode and use a separate `text_idx` for filename generation.

### 2. `example_onnx.py` — Missing `--lang` validation

The script validates `len(voice_style_paths) == len(text_list)` but never validates `len(lang_list)`. If a user passes 3 texts and 2 languages, the `zip(text_list, lang_list)` in the text processor silently drops the third text. 

**Fix:** Added an assertion that `len(lang_list)` matches `len(text_list)` or is exactly 1. If it's 1, it auto-broadcasts to match the text count (common use case: same language for all inputs).

### 3. `helper.py` — Emoji regex recompiled on every `_preprocess_text()` call

The emoji removal regex was being `re.compile()`'d inside `_preprocess_text()`, which gets called once per text chunk. For longer inputs that get split into many chunks, this adds up.

**Fix:** Moved the pattern to module-level `_EMOJI_PATTERN` so it compiles once at import time.

## Files Changed

- `py/example_onnx.py` — bug fixes for non-batch crash and lang validation
- `py/helper.py` — performance fix for regex compilation

Let me know if anything needs adjusting!
