### PR TITLE
docs: hyphenate lightning-fast in Python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ tts = TTS(auto_download=True)
 
 style = tts.get_voice_style(voice_name="M1")
 
-text = "Supertonic is a lightning fast, on-device TTS system."
+text = "Supertonic is a lightning-fast, on-device TTS system."
 
 wav, duration = tts.synthesize(
     text=text,


### PR DESCRIPTION
## Summary\n- hyphenate 'lightning-fast' in the README Python example\n- align the example wording with the rest of the README\n\n## Testing\n- not needed (documentation-only change)