### PR TITLE
docs(readme): document `--speed` flag in Go/Rust/Java/Swift args tables

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -138,6 +138,7 @@ This will:
 | `-use-gpu` | flag | false | Use GPU for inference (default: CPU) |
 | `-onnx-dir` | str | `../assets/onnx` | Path to ONNX model directory |
 | `-total-step` | int | 8 | Number of denoising steps (higher = better quality, slower) |
+| `-speed` | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |
 | `-n-test` | int | 4 | Number of times to generate each sample |
 | `-voice-style` | str | `../assets/voice_styles/M1.json` | Voice style file path(s), comma-separated |
 | `-text` | str | (long default text) | Text(s) to synthesize, pipe-separated |

--- a/java/README.md
+++ b/java/README.md
@@ -120,6 +120,7 @@ java -jar target/tts-example.jar --total-step 10 --text "Your custom text here"
 | `--use-gpu` | flag | False | Use GPU for inference (default: CPU) |
 | `--onnx-dir` | str | `../assets/onnx` | Path to ONNX model directory |
 | `--total-step` | int | 8 | Number of denoising steps (higher = better quality, slower) |
+| `--speed` | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |
 | `--n-test` | int | 4 | Number of times to generate each sample |
 | `--voice-style` | str+ | `../assets/voice_styles/M1.json` | Voice style file path(s), comma-separated |
 | `--text` | str+ | (long default text) | Text(s) to synthesize, pipe-separated |

--- a/rust/README.md
+++ b/rust/README.md
@@ -127,6 +127,7 @@ This will:
 | `--use-gpu` | flag | False | Use GPU for inference (default: CPU) |
 | `--onnx-dir` | str | `../assets/onnx` | Path to ONNX model directory |
 | `--total-step` | int | 8 | Number of denoising steps (higher = better quality, slower) |
+| `--speed` | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |
 | `--n-test` | int | 4 | Number of times to generate each sample |
 | `--voice-style` | str+ | `../assets/voice_styles/M1.json` | Voice style file path(s), comma-separated |
 | `--text` | str+ | (long default text) | Text(s) to synthesize, pipe-separated |

--- a/swift/README.md
+++ b/swift/README.md
@@ -97,6 +97,7 @@ This will:
 | `--use-gpu` | flag | False | Use GPU for inference (default: CPU) |
 | `--onnx-dir` | str | `../assets/onnx` | Path to ONNX model directory |
 | `--total-step` | int | 8 | Number of denoising steps (higher = better quality, slower) |
+| `--speed` | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |
 | `--n-test` | int | 4 | Number of times to generate each sample |
 | `--voice-style` | str+ | `../assets/voice_styles/M1.json` | Voice style file path(s) |
 | `--text` | str+ | (long default text) | Text(s) to synthesize |


### PR DESCRIPTION
## Summary

The `--speed` parameter was announced in each language README's **Update News** entry dated **2025.11.19**:

> **2025.11.19** - Added `--speed` parameter to control speech synthesis speed (default: 1.05, recommended range: 0.9-1.5).

…and the example code already accepts it in every language. But 4 of the 8 language READMEs forgot to add the corresponding row to the **Available Arguments** reference table, so the flag is essentially invisible to anyone using that table as the source of truth.

| README | `--speed` in args table before this PR |
|---|:---:|
| `py/README.md` | ✓ |
| `nodejs/README.md` | ✓ |
| `csharp/README.md` | ✓ |
| `cpp/README.md` | ✓ |
| `go/README.md` | ❌ |
| `rust/README.md` | ❌ |
| `java/README.md` | ❌ |
| `swift/README.md` | ❌ |

## Why a maintainer should care

- Users who copy from the args table can't discover the shipped speed control without reading source.
- The wording is already standardized across the 4 READMEs that have it — no new copy is invented here, just the same row added.
- Zero behavior change, zero code change — strictly aligns docs with implementation.

## Evidence the flag already exists in code

- `go/example_onnx.go` — `flag.Float64Var(&args.speed, "speed", 1.05, "Speech speed factor (higher = faster)")`
- `rust/src/example_onnx.rs` — `#[arg(long, default_value = "1.05")] speed: f32`
- `java/ExampleONNX.java` — `float speed = 1.05f;` and `case "--speed": …`
- `swift/Sources/ExampleONNX.swift` — `var speed: Float = 1.05` and `case "--speed": …`

## Style notes

- Each row mirrors verbatim the wording used in `py/README.md`, `nodejs/README.md`, `csharp/README.md`, `cpp/README.md`:
  `| --speed | float | 1.05 | Speech speed factor (higher = faster, lower = slower) |`
- Inserted at the same position (immediately after `--total-step`).
- Go uses single-dash (`-speed`) to match the surrounding rows in the Go table (`-use-gpu`, `-onnx-dir`, `-total-step`, …). Go's `flag` package accepts both `-speed` and `--speed`.

## Test plan

- [x] Each affected example file confirmed to accept `--speed` already (links above).
- [x] Inserted row is byte-identical (modulo dash style for Go) to the existing row in `py`/`nodejs`/`csharp`/`cpp` READMEs.
- [x] No code paths touched; nothing to run or rebuild.
- [x] `git diff` is exactly 4 lines added, 0 lines removed.
