### PR TITLE
docs: add Aftertone to Built with Supertonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Supertonic is designed to handle complex, real-world text inputs that contain na
 | **VoiceChat** | On-device voice-to-voice LLM chatbot in the browser | [Demo](https://huggingface.co/spaces/RickRossTN/ai-voice-chat) · [GitHub](https://github.com/irelate-ai/voice-chat) |
 | **OmniAvatar** | Talking avatar video generator from photo + speech | [Demo](https://huggingface.co/spaces/alexnasa/OmniAvatar) |
 | **CopiloTTS** | Kotlin Multiplatform TTS SDK via ONNX Runtime | [GitHub](https://github.com/sigmadeltasoftware/CopiloTTS) |
+| **Aftertone** | Local post-reply TTS for Cursor & Claude Code (Supertonic 3 ONNX, on-device daemon) | [GitHub](https://github.com/omarelkhal/aftertone) · [Demo](https://github.com/omarelkhal/aftertone/releases/download/demo-asset/demo.mp4) |
 | **Voice Mixer** | PyQt5 tool for mixing and modifying voice styles | [GitHub](https://github.com/Topping1/Supertonic-Voice-Mixer) |
 | **Supertonic MNN** | Lightweight library based on MNN (fp32/fp16/int8) | [GitHub](https://github.com/vra/supertonic-mnn) · [PyPI](https://pypi.org/project/supertonic-mnn/) |
 | **Transformers.js** | Hugging Face's JS library with Supertonic support | [GitHub PR](https://github.com/huggingface/transformers.js/pull/1459) · [Demo](https://huggingface.co/spaces/webml-community/Supertonic-TTS-WebGPU) |


### PR DESCRIPTION
## Summary

Adds **[Aftertone](https://github.com/omarelkhal/aftertone)** to the **Built with Supertonic** table in `README.md`.

Aftertone is a separate MIT project (not a fork of this repo) that:

- Runs **local** post-reply TTS for **Cursor** and **Claude Code** via agent hooks
- Uses **Supertonic 3** ONNX assets from [Supertone/supertonic-3](https://huggingface.co/Supertone/supertonic-3) (OpenRAIL-M weights; MIT app code)
- Keeps models loaded in an on-device `tts_daemon` (no cloud TTS API)

https://github.com/user-attachments/assets/9feb0c63-c421-46e3-a456-a05e0338f248

**Links:** [GitHub](https://github.com/omarelkhal/aftertone) · [Docs](https://omarelkhal.github.io/aftertone/) . [Demo](https://github.com/user-attachments/assets/9feb0c63-c421-46e3-a456-a05e0338f248)

Happy to adjust wording or placement in the table if maintainers prefer.


