### PR TITLE
docs: add react-native-tts-kit to Built with Supertonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Supertonic is designed to handle complex, real-world text inputs that contain na
 | **Supertonic MNN** | Lightweight library based on MNN (fp32/fp16/int8) | [GitHub](https://github.com/vra/supertonic-mnn) · [PyPI](https://pypi.org/project/supertonic-mnn/) |
 | **Transformers.js** | Hugging Face's JS library with Supertonic support | [GitHub PR](https://github.com/huggingface/transformers.js/pull/1459) · [Demo](https://huggingface.co/spaces/webml-community/Supertonic-TTS-WebGPU) |
 | **Pinokio** | 1-click localhost cloud for Mac, Windows, and Linux | [Pinokio](https://pinokio.co/) · [GitHub](https://github.com/SUP3RMASS1VE/SuperTonic-TTS) |
+| **react-native-tts-kit** | On-device neural TTS for React Native & Expo (Supertonic-3 ONNX, 31 languages) | [GitHub](https://github.com/ahk-d/react-native-tts-kit) · [npm](https://www.npmjs.com/package/react-native-tts-kit) |
 
 ## Models & Versions
 


### PR DESCRIPTION
Adds **react-native-tts-kit** to the *Built with Supertonic* showcase — on-device neural TTS for React Native & Expo.

- GitHub: https://github.com/ahk-d/react-native-tts-kit
- npm: https://www.npmjs.com/package/react-native-tts-kit

Thanks for open-sourcing Supertonic-3 — it does the heavy lifting here. 🙏