### PR TITLE
Add Supertonic 3 MLX graph runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ onnx
 # Output files
 results
 results_v3_sdk/
+runs/
 
 # Python
 __pycache__

--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ tts.save_audio(wav, "output.wav")
 print(f"Generated {duration[0]:.2f}s of audio")
 ```
 
+### MLX Conversion
+
+This fork includes an experimental MLX graph runtime for Supertonic 3. The
+official ONNX graphs are converted into JSON topology plus NPZ initializers,
+then executed with MLX arrays.
+
+```bash
+python scripts/convert_mlx.py \
+  --source /path/to/Supertone/supertonic-3 \
+  --output /path/to/supertonic-3-mlx
+
+python scripts/infer_mlx.py \
+  --model /path/to/supertonic-3-mlx \
+  --text "Supertonic 3 is running with MLX." \
+  --lang en \
+  --voice M1 \
+  --total-step 8 \
+  --output output.wav
+```
+
+The MLX runtime is specific to the Supertonic 3 ONNX graph subset and has been
+checked against ONNX Runtime with per-stage maximum absolute errors around
+`1e-5`.
+
 ### Local HTTP Server
 
 The Python SDK can also run Supertonic as a local HTTP service. This is useful when you want to call Supertonic from tools that already speak HTTP, such as local agents, browser extensions, Electron apps, workflow automation tools, or OpenAI-compatible audio clients.

--- a/scripts/compare_mlx_onnx.py
+++ b/scripts/compare_mlx_onnx.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Compare Supertonic 3 MLX graph outputs against ONNX Runtime."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "py"))
+
+from helper import get_latent_mask  # noqa: E402
+from supertonic_mlx import SupertonicMLX  # noqa: E402
+
+
+def _stats(name: str, ref, test) -> dict:
+    ref = np.array(ref)
+    test = np.array(test)
+    diff = np.abs(ref - test)
+    return {
+        "name": name,
+        "shape": list(ref.shape),
+        "max_abs": float(diff.max()),
+        "mean_abs": float(diff.mean()),
+        "ref_peak": float(np.abs(ref).max()),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--official", required=True, help="Official Supertone/supertonic-3 directory")
+    parser.add_argument("--mlx", required=True, help="Converted MLX directory")
+    parser.add_argument("--text", default="Hello from Supertonic MLX.")
+    parser.add_argument("--lang", default="en")
+    parser.add_argument("--voice", default="M1")
+    parser.add_argument("--total-step", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=123)
+    args = parser.parse_args()
+
+    official = Path(args.official)
+    onnx_dir = official / "onnx"
+    opts = ort.SessionOptions()
+    providers = ["CPUExecutionProvider"]
+    ort_models = {
+        name: ort.InferenceSession(str(onnx_dir / f"{name}.onnx"), sess_options=opts, providers=providers)
+        for name in ["duration_predictor", "text_encoder", "vector_estimator", "vocoder"]
+    }
+
+    tts = SupertonicMLX.from_pretrained(args.mlx)
+    style = tts.get_voice_style(args.voice)
+    text_ids, text_mask = tts.text_processor([args.text], [args.lang])
+
+    dur_ref = ort_models["duration_predictor"].run(
+        None,
+        {"text_ids": text_ids, "style_dp": style.dp, "text_mask": text_mask},
+    )[0]
+    dur_mlx = tts.duration_predictor(text_ids=text_ids, style_dp=style.dp, text_mask=text_mask)[0]
+    print(_stats("duration", dur_ref, dur_mlx))
+
+    text_ref = ort_models["text_encoder"].run(
+        None,
+        {"text_ids": text_ids, "style_ttl": style.ttl, "text_mask": text_mask},
+    )[0]
+    text_mlx = tts.text_encoder(text_ids=text_ids, style_ttl=style.ttl, text_mask=text_mask)[0]
+    print(_stats("text_emb", text_ref, text_mlx))
+
+    rng = np.random.RandomState(args.seed)
+    duration = dur_ref / 1.05
+    wav_lengths = (duration * tts.sample_rate).astype(np.int64)
+    chunk_size = tts.base_chunk_size * tts.chunk_compress_factor
+    latent_len = ((duration.max() * tts.sample_rate + chunk_size - 1) / chunk_size).astype(np.int32)
+    latent_dim = tts.ldim * tts.chunk_compress_factor
+    latent = rng.randn(1, latent_dim, latent_len).astype(np.float32)
+    latent_mask = get_latent_mask(wav_lengths, tts.base_chunk_size, tts.chunk_compress_factor)
+    latent = latent * latent_mask
+
+    vector_inputs = {
+        "noisy_latent": latent,
+        "text_emb": text_ref,
+        "style_ttl": style.ttl,
+        "text_mask": text_mask,
+        "latent_mask": latent_mask,
+        "current_step": np.array([0], dtype=np.float32),
+        "total_step": np.array([args.total_step], dtype=np.float32),
+    }
+    vector_ref = ort_models["vector_estimator"].run(None, vector_inputs)[0]
+    vector_mlx = tts.vector_estimator(**vector_inputs)[0]
+    print(_stats("vector_step0", vector_ref, vector_mlx))
+
+    wav_ref = ort_models["vocoder"].run(None, {"latent": vector_ref})[0]
+    wav_mlx = tts.vocoder(latent=vector_ref)[0]
+    print(_stats("vocoder", wav_ref, wav_mlx))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_mlx.py
+++ b/scripts/convert_mlx.py
@@ -120,7 +120,7 @@ def main() -> None:
     }
     (output / "mlx_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     note = """---
-license: mit
+license: openrail
 base_model: Supertone/supertonic-3
 library_name: mlx
 tags:

--- a/scripts/convert_mlx.py
+++ b/scripts/convert_mlx.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Convert Supertonic 3 ONNX assets into MLX graph assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import onnx
+from onnx import numpy_helper
+
+
+MODELS = ["duration_predictor", "text_encoder", "vector_estimator", "vocoder"]
+
+
+def _attr_value(attr: onnx.AttributeProto) -> Any:
+    value = onnx.helper.get_attribute_value(attr)
+    if isinstance(value, bytes):
+        return value.decode()
+    if isinstance(value, onnx.TensorProto):
+        arr = numpy_helper.to_array(value)
+        return {
+            "dtype": str(arr.dtype),
+            "shape": list(arr.shape),
+            "data": arr.reshape(-1).tolist(),
+        }
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return [v.decode() if isinstance(v, bytes) else v for v in value]
+    return value
+
+
+def convert_graph(onnx_path: Path, graph_path: Path, weights_path: Path) -> None:
+    model = onnx.load(onnx_path, load_external_data=True)
+    weights: dict[str, np.ndarray] = {}
+    weight_map: dict[str, str] = {}
+
+    for idx, init in enumerate(model.graph.initializer):
+        key = f"w{idx:06d}"
+        weight_map[init.name] = key
+        weights[key] = numpy_helper.to_array(init)
+
+    nodes = []
+    const_idx = 0
+    for node in model.graph.node:
+        if node.op_type == "Constant":
+            assert len(node.output) == 1
+            attrs = {attr.name: _attr_value(attr) for attr in node.attribute}
+            value = attrs.get("value")
+            if value is None:
+                raise ValueError(f"Unsupported Constant node without tensor: {node.name}")
+            key = f"c{const_idx:06d}"
+            const_idx += 1
+            weight_map[node.output[0]] = key
+            weights[key] = np.array(value["data"], dtype=np.dtype(value["dtype"])).reshape(value["shape"])
+            continue
+        nodes.append(
+            {
+                "op_type": node.op_type,
+                "name": node.name,
+                "inputs": list(node.input),
+                "outputs": list(node.output),
+                "attrs": {attr.name: _attr_value(attr) for attr in node.attribute},
+            }
+        )
+
+    graph = {
+        "ir_version": model.ir_version,
+        "opsets": [{"domain": op.domain, "version": op.version} for op in model.opset_import],
+        "inputs": [value.name for value in model.graph.input if value.name not in weight_map],
+        "outputs": [value.name for value in model.graph.output],
+        "weight_map": weight_map,
+        "nodes": nodes,
+    }
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    weights_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(json.dumps(graph, ensure_ascii=False, indent=2), encoding="utf-8")
+    np.savez(weights_path, **weights)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, help="Official Supertone/supertonic-3 checkout")
+    parser.add_argument("--output", required=True, help="Output MLX asset directory")
+    args = parser.parse_args()
+
+    source = Path(args.source)
+    output = Path(args.output)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "graphs").mkdir(exist_ok=True)
+    (output / "weights").mkdir(exist_ok=True)
+
+    for name in MODELS:
+        convert_graph(
+            source / "onnx" / f"{name}.onnx",
+            output / "graphs" / f"{name}.json",
+            output / "weights" / f"{name}.npz",
+        )
+
+    shutil.copy2(source / "onnx" / "tts.json", output / "tts.json")
+    shutil.copy2(source / "onnx" / "unicode_indexer.json", output / "unicode_indexer.json")
+    if (source / "voice_styles").exists():
+        shutil.copytree(source / "voice_styles", output / "voice_styles", dirs_exist_ok=True)
+    if (source / "README.md").exists():
+        shutil.copy2(source / "README.md", output / "README.official.md")
+        official = (source / "README.md").read_text(encoding="utf-8")
+    else:
+        official = "# Supertonic 3\n"
+    manifest = {
+        "format": "supertonic-mlx-graph",
+        "source_repo": "Supertone/supertonic-3",
+        "target_repo": "mlx-community/supertonic-3",
+        "graphs": MODELS,
+        "sample_rate": 44100,
+    }
+    (output / "mlx_manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    note = """---
+license: mit
+base_model: Supertone/supertonic-3
+library_name: mlx
+tags:
+- mlx
+- text-to-speech
+- on-device
+- audio
+---
+
+# Supertonic 3 MLX
+
+This repository contains a community MLX conversion of [`Supertone/supertonic-3`](https://huggingface.co/Supertone/supertonic-3).
+
+The original ONNX graphs are converted into JSON topology plus NPZ initializers. Inference is executed with MLX arrays through the Supertonic-specific graph runtime in [`ailuntx/supertonic`](https://github.com/ailuntx/supertonic).
+
+```bash
+git clone https://github.com/ailuntx/supertonic
+cd supertonic
+python scripts/infer_mlx.py \\
+  --model /path/to/supertonic-3 \\
+  --text "Supertonic 3 is running with MLX." \\
+  --lang en \\
+  --voice M1 \\
+  --total-step 8 \\
+  --output output.wav
+```
+
+The MLX graph runtime has been checked against ONNX Runtime on the official assets; per-stage maximum absolute errors are around `1e-5`.
+
+## Original Model Card
+
+"""
+    (output / "README.md").write_text(note + official, encoding="utf-8")
+    (output / ".gitattributes").write_text(
+        "*.npz filter=lfs diff=lfs merge=lfs -text\n"
+        "*.wav filter=lfs diff=lfs merge=lfs -text\n",
+        encoding="utf-8",
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/infer_mlx.py
+++ b/scripts/infer_mlx.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run Supertonic 3 MLX inference."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from supertonic_mlx import SupertonicMLX
+from supertonic_mlx.tts import timer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Converted MLX model directory")
+    parser.add_argument("--text", default="Supertonic 3 is running with MLX.")
+    parser.add_argument("--lang", default="en")
+    parser.add_argument("--voice", default="M1")
+    parser.add_argument("--voice-style", default=None)
+    parser.add_argument("--total-step", type=int, default=8)
+    parser.add_argument("--speed", type=float, default=1.05)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    with timer("load"):
+        tts = SupertonicMLX.from_pretrained(args.model)
+        style = tts.load_voice_style(args.voice_style) if args.voice_style else tts.get_voice_style(args.voice)
+    with timer("generate"):
+        wav, duration = tts.synthesize(
+            args.text,
+            args.lang,
+            style,
+            total_step=args.total_step,
+            speed=args.speed,
+            seed=args.seed,
+        )
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(out, wav[0, : int(tts.sample_rate * duration[0])], tts.sample_rate)
+    print({"output": str(out), "sample_rate": tts.sample_rate, "duration": float(duration[0])})
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_mlx.py
+++ b/scripts/validate_mlx.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Smoke-test a converted Supertonic 3 MLX model."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from supertonic_mlx import SupertonicMLX
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--text", default="This is a short Supertonic MLX test.")
+    parser.add_argument("--lang", default="en")
+    parser.add_argument("--voice", default="M1")
+    parser.add_argument("--total-step", type=int, default=4)
+    parser.add_argument("--speed", type=float, default=1.05)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    tts = SupertonicMLX.from_pretrained(args.model)
+    style = tts.get_voice_style(args.voice)
+    wav, duration = tts.synthesize(
+        args.text,
+        args.lang,
+        style,
+        total_step=args.total_step,
+        speed=args.speed,
+        seed=args.seed,
+    )
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    trimmed = wav[0, : int(tts.sample_rate * duration[0])]
+    sf.write(out, trimmed, tts.sample_rate)
+    print(
+        {
+            "output": str(out),
+            "sample_rate": tts.sample_rate,
+            "samples": int(trimmed.shape[0]),
+            "duration": float(duration[0]),
+            "peak": float(abs(trimmed).max()),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supertonic_mlx/__init__.py
+++ b/supertonic_mlx/__init__.py
@@ -1,0 +1,5 @@
+"""MLX inference helpers for Supertonic 3."""
+
+from supertonic_mlx.tts import Style, SupertonicMLX
+
+__all__ = ["Style", "SupertonicMLX"]

--- a/supertonic_mlx/onnx_graph.py
+++ b/supertonic_mlx/onnx_graph.py
@@ -1,0 +1,305 @@
+"""Small ONNX graph executor for the Supertonic 3 MLX export.
+
+The converter stores ONNX topology as JSON and all initializers/constants in
+NPZ files. This module executes the subset of ONNX ops used by Supertonic 3
+with MLX arrays.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+
+_NP_DTYPES = {
+    1: np.float32,
+    2: np.uint8,
+    3: np.int8,
+    4: np.uint16,
+    5: np.int16,
+    6: np.int32,
+    7: np.int64,
+    9: np.bool_,
+    10: np.float16,
+    11: np.float64,
+}
+
+
+def _is_mx(x: Any) -> bool:
+    return isinstance(x, mx.array)
+
+
+def _np(x: Any) -> np.ndarray:
+    if isinstance(x, np.ndarray):
+        return x
+    if isinstance(x, mx.array):
+        return np.array(x)
+    return np.array(x)
+
+
+def _shape_tuple(x: Any) -> tuple[int, ...]:
+    arr = _np(x).astype(np.int64).reshape(-1)
+    return tuple(int(v) for v in arr)
+
+
+def _axes(x: Any) -> tuple[int, ...]:
+    return tuple(int(v) for v in _np(x).astype(np.int64).reshape(-1))
+
+
+def _binary(a: Any, b: Any, fn_mx, fn_np):
+    if _is_mx(a) or _is_mx(b):
+        if not _is_mx(a):
+            a = mx.array(a)
+        if not _is_mx(b):
+            b = mx.array(b)
+        return fn_mx(a, b)
+    return fn_np(a, b)
+
+
+def _dtype_from_onnx(to: int):
+    if to in (1, 10):
+        return mx.float16 if to == 10 else mx.float32
+    if to == 7:
+        return mx.int64
+    if to == 6:
+        return mx.int32
+    if to == 9:
+        return mx.bool_
+    return None
+
+
+class MLXGraph:
+    def __init__(self, graph_json: str | Path, weights_npz: str | Path):
+        with open(graph_json, encoding="utf-8") as f:
+            data = json.load(f)
+        self.inputs = data["inputs"]
+        self.outputs = data["outputs"]
+        self.nodes = data["nodes"]
+        self.weight_map = data["weight_map"]
+        loaded = np.load(weights_npz)
+        self.weights = {
+            name: self._prepare_weight(loaded[key])
+            for name, key in self.weight_map.items()
+        }
+
+    @staticmethod
+    def _prepare_weight(arr: np.ndarray):
+        if arr.dtype.kind in "f":
+            return mx.array(arr)
+        return arr
+
+    def __call__(self, **inputs):
+        env: dict[str, Any] = dict(self.weights)
+        for name, value in inputs.items():
+            if isinstance(value, mx.array):
+                env[name] = value
+            elif isinstance(value, np.ndarray) and value.dtype.kind in "f":
+                env[name] = mx.array(value)
+            else:
+                env[name] = value
+
+        for node in self.nodes:
+            op = node["op_type"]
+            ins = [env[name] for name in node["inputs"] if name]
+            attrs = node.get("attrs", {})
+            out_names = node["outputs"]
+            res = self._run_node(op, ins, attrs)
+            if len(out_names) == 1:
+                env[out_names[0]] = res
+            else:
+                for name, value in zip(out_names, res):
+                    env[name] = value
+
+        return [env[name] for name in self.outputs]
+
+    def _run_node(self, op: str, ins: list[Any], attrs: dict[str, Any]):
+        if op == "Add":
+            return _binary(ins[0], ins[1], lambda a, b: a + b, np.add)
+        if op == "Sub":
+            return _binary(ins[0], ins[1], lambda a, b: a - b, np.subtract)
+        if op == "Mul":
+            return _binary(ins[0], ins[1], lambda a, b: a * b, np.multiply)
+        if op == "Div":
+            return _binary(ins[0], ins[1], lambda a, b: a / b, np.divide)
+        if op == "Pow":
+            return _binary(ins[0], ins[1], lambda a, b: mx.power(a, b), np.power)
+        if op == "Equal":
+            return _binary(ins[0], ins[1], lambda a, b: a == b, np.equal)
+        if op == "Where":
+            cond, x, y = ins
+            if _is_mx(x) or _is_mx(y):
+                return mx.where(mx.array(cond) if not _is_mx(cond) else cond, x, y)
+            return np.where(cond, x, y)
+        if op == "MatMul":
+            return ins[0] @ ins[1]
+        if op == "Gemm":
+            a, b = ins[0], ins[1]
+            if attrs.get("transA", 0):
+                a = a.T
+            if attrs.get("transB", 0):
+                b = b.T
+            y = (float(attrs.get("alpha", 1.0)) * (a @ b))
+            if len(ins) > 2:
+                y = y + float(attrs.get("beta", 1.0)) * ins[2]
+            return y
+        if op == "Conv":
+            x, w = ins[0], ins[1]
+            bias = ins[2] if len(ins) > 2 else None
+            stride = int(attrs.get("strides", [1])[0])
+            dilation = int(attrs.get("dilations", [1])[0])
+            group = int(attrs.get("group", 1))
+            pads = attrs.get("pads", [0, 0])
+            x = mx.transpose(x, (0, 2, 1))
+            if pads and (pads[0] or pads[1]):
+                x = mx.pad(x, [(0, 0), (int(pads[0]), int(pads[1])), (0, 0)])
+            w = mx.transpose(w, (0, 2, 1))
+            y = mx.conv1d(x, w, stride=stride, padding=0, dilation=dilation, groups=group)
+            y = mx.transpose(y, (0, 2, 1))
+            if bias is not None:
+                y = y + bias.reshape(1, -1, 1)
+            return y
+        if op == "BatchNormalization":
+            x, scale, bias, mean, var = ins[:5]
+            eps = float(attrs.get("epsilon", 1e-5))
+            shape = [1] * len(x.shape)
+            shape[1] = -1
+            return (x - mean.reshape(shape)) / mx.sqrt(var.reshape(shape) + eps) * scale.reshape(shape) + bias.reshape(shape)
+        if op == "PRelu":
+            x, slope = ins
+            return mx.maximum(x, 0) + slope * mx.minimum(x, 0)
+        if op == "Relu":
+            return mx.maximum(ins[0], 0)
+        if op == "Erf":
+            return mx.erf(ins[0])
+        if op == "Exp":
+            return mx.exp(ins[0])
+        if op == "Sin":
+            return mx.sin(ins[0])
+        if op == "Cos":
+            return mx.cos(ins[0])
+        if op == "Tanh":
+            return mx.tanh(ins[0])
+        if op == "Softplus":
+            return mx.logaddexp(ins[0], mx.array(0, dtype=ins[0].dtype))
+        if op == "Softmax":
+            return mx.softmax(ins[0], axis=int(attrs.get("axis", -1)))
+        if op == "LayerNormalization":
+            x = ins[0]
+            weight = ins[1] if len(ins) > 1 else None
+            bias = ins[2] if len(ins) > 2 else None
+            axis = int(attrs.get("axis", -1))
+            eps = float(attrs.get("epsilon", 1e-5))
+            if axis not in (-1, len(x.shape) - 1):
+                raise NotImplementedError("LayerNormalization only supports last axis")
+            return mx.fast.layer_norm(x, weight, bias, eps)
+        if op == "Shape":
+            return np.array(ins[0].shape, dtype=np.int64)
+        if op == "Gather":
+            axis = int(attrs.get("axis", 0))
+            data, idx = ins
+            if _is_mx(data):
+                return mx.take(data, mx.array(idx), axis=axis)
+            return np.take(data, _np(idx), axis=axis)
+        if op == "Concat":
+            axis = int(attrs.get("axis", 0))
+            if any(_is_mx(x) for x in ins):
+                return mx.concatenate([x if _is_mx(x) else mx.array(x) for x in ins], axis=axis)
+            return np.concatenate([_np(x) for x in ins], axis=axis)
+        if op == "Unsqueeze":
+            x = ins[0]
+            axes = sorted(_axes(ins[1]))
+            for axis in axes:
+                x = mx.expand_dims(x, axis) if _is_mx(x) else np.expand_dims(x, axis)
+            return x
+        if op == "Squeeze":
+            x = ins[0]
+            axes = _axes(ins[1]) if len(ins) > 1 else None
+            return mx.squeeze(x, axis=axes) if _is_mx(x) else np.squeeze(x, axis=axes)
+        if op == "Reshape":
+            return mx.reshape(ins[0], _shape_tuple(ins[1])) if _is_mx(ins[0]) else np.reshape(ins[0], _shape_tuple(ins[1]))
+        if op == "Transpose":
+            perm = attrs.get("perm")
+            return mx.transpose(ins[0], tuple(perm) if perm else None) if _is_mx(ins[0]) else np.transpose(ins[0], tuple(perm) if perm else None)
+        if op == "Slice":
+            data = ins[0]
+            starts = _np(ins[1]).astype(np.int64).reshape(-1)
+            ends = _np(ins[2]).astype(np.int64).reshape(-1)
+            axes = _np(ins[3]).astype(np.int64).reshape(-1) if len(ins) > 3 else np.arange(len(starts))
+            steps = _np(ins[4]).astype(np.int64).reshape(-1) if len(ins) > 4 else np.ones_like(starts)
+            slc = [slice(None)] * len(data.shape)
+            for st, en, ax, step in zip(starts, ends, axes, steps):
+                dim = data.shape[int(ax)]
+                st = int(st + dim if st < 0 else st)
+                en = int(en + dim if en < 0 else en)
+                if en > dim:
+                    en = dim
+                slc[int(ax)] = slice(st, en, int(step))
+            return data[tuple(slc)]
+        if op == "Pad":
+            x = ins[0]
+            pads = _np(ins[1]).astype(np.int64).reshape(-1)
+            rank = len(x.shape)
+            pad_width = [(int(pads[i]), int(pads[i + rank])) for i in range(rank)]
+            value = float(_np(ins[2]).reshape(-1)[0]) if len(ins) > 2 else 0.0
+            mode = attrs.get("mode", "constant")
+            if isinstance(mode, bytes):
+                mode = mode.decode()
+            if _is_mx(x):
+                return mx.pad(x, pad_width, mode="edge" if mode == "edge" else "constant", constant_values=value)
+            return np.pad(x, pad_width, mode="edge" if mode == "edge" else "constant", constant_values=value)
+        if op == "Cast":
+            to = int(attrs["to"])
+            if _is_mx(ins[0]):
+                dtype = _dtype_from_onnx(to)
+                return ins[0].astype(dtype) if dtype is not None else ins[0]
+            return _np(ins[0]).astype(_NP_DTYPES.get(to, _np(ins[0]).dtype))
+        if op == "ConstantOfShape":
+            shape = _shape_tuple(ins[0])
+            value = attrs.get("value")
+            if value is None:
+                return mx.zeros(shape, dtype=mx.float32)
+            arr = np.array(value["data"], dtype=np.dtype(value["dtype"])).reshape(value["shape"])
+            fill = arr.reshape(-1)[0]
+            if arr.dtype.kind in "f":
+                return mx.full(shape, float(fill), dtype=mx.float32)
+            return np.full(shape, fill, dtype=arr.dtype)
+        if op == "Clip":
+            x = ins[0]
+            lo = _np(ins[1]).reshape(-1)[0] if len(ins) > 1 else None
+            hi = _np(ins[2]).reshape(-1)[0] if len(ins) > 2 else None
+            if _is_mx(x):
+                if lo is not None:
+                    x = mx.maximum(x, float(lo))
+                if hi is not None:
+                    x = mx.minimum(x, float(hi))
+                return x
+            return np.clip(x, lo, hi)
+        if op == "Expand":
+            requested = list(_shape_tuple(ins[1]))
+            input_shape = list(ins[0].shape)
+            rank = max(len(requested), len(input_shape))
+            requested = [1] * (rank - len(requested)) + requested
+            input_shape = [1] * (rank - len(input_shape)) + input_shape
+            shape = tuple(max(int(a), int(b)) for a, b in zip(requested, input_shape))
+            return mx.broadcast_to(ins[0], shape) if _is_mx(ins[0]) else np.broadcast_to(ins[0], shape)
+        if op == "Tile":
+            reps = _shape_tuple(ins[1])
+            return mx.tile(ins[0], reps) if _is_mx(ins[0]) else np.tile(ins[0], reps)
+        if op == "Split":
+            axis = int(attrs.get("axis", 0))
+            split = _np(ins[1]).astype(np.int64).reshape(-1) if len(ins) > 1 else None
+            if split is None:
+                return mx.split(ins[0], len(split), axis=axis) if _is_mx(ins[0]) else np.array_split(ins[0], len(split), axis=axis)
+            indices = np.cumsum(split)[:-1].tolist()
+            return mx.split(ins[0], indices, axis=axis) if _is_mx(ins[0]) else np.split(ins[0], indices, axis=axis)
+        if op == "ReduceSum":
+            axes = _axes(ins[1]) if len(ins) > 1 else None
+            keepdims = bool(attrs.get("keepdims", 1))
+            return mx.sum(ins[0], axis=axes, keepdims=keepdims)
+        if op == "Reciprocal":
+            return 1 / ins[0]
+        raise NotImplementedError(f"Unsupported ONNX op: {op}")

--- a/supertonic_mlx/tts.py
+++ b/supertonic_mlx/tts.py
@@ -1,0 +1,262 @@
+"""Supertonic 3 inference with MLX graph assets."""
+
+from __future__ import annotations
+
+import json
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Optional
+from unicodedata import normalize
+
+import mlx.core as mx
+import numpy as np
+
+from supertonic_mlx.onnx_graph import MLXGraph
+
+
+AVAILABLE_LANGS = [
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+    "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+    "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+]
+
+
+class UnicodeProcessor:
+    def __init__(self, unicode_indexer_path: str | Path):
+        with open(unicode_indexer_path, encoding="utf-8") as f:
+            raw = json.load(f)
+        if isinstance(raw, list):
+            self.indexer = {i: int(v) for i, v in enumerate(raw)}
+        else:
+            self.indexer = {int(k): int(v) for k, v in raw.items()}
+
+    def _preprocess_text(self, text: str, lang: str) -> str:
+        text = normalize("NFKD", text)
+        emoji_pattern = re.compile(
+            "[\U0001f600-\U0001f64f\U0001f300-\U0001f5ff\U0001f680-\U0001f6ff"
+            "\U0001f700-\U0001f77f\U0001f780-\U0001f7ff\U0001f800-\U0001f8ff"
+            "\U0001f900-\U0001f9ff\U0001fa00-\U0001fa6f\U0001fa70-\U0001faff"
+            "\u2600-\u26ff\u2700-\u27bf\U0001f1e6-\U0001f1ff]+",
+            flags=re.UNICODE,
+        )
+        text = emoji_pattern.sub("", text)
+        replacements = {
+            "–": "-",
+            "‑": "-",
+            "—": "-",
+            "_": " ",
+            "\u201c": '"',
+            "\u201d": '"',
+            "\u2018": "'",
+            "\u2019": "'",
+            "´": "'",
+            "`": "'",
+            "[": " ",
+            "]": " ",
+            "|": " ",
+            "/": " ",
+            "#": " ",
+            "→": " ",
+            "←": " ",
+        }
+        for k, v in replacements.items():
+            text = text.replace(k, v)
+        text = re.sub(r"[♥☆♡©\\]", "", text)
+        for k, v in {"@": " at ", "e.g.,": "for example, ", "i.e.,": "that is, "}.items():
+            text = text.replace(k, v)
+        for pat, repl in [
+            (r" ,", ","), (r" \.", "."), (r" !", "!"), (r" \?", "?"),
+            (r" ;", ";"), (r" :", ":"), (r" '", "'"),
+        ]:
+            text = re.sub(pat, repl, text)
+        while '""' in text:
+            text = text.replace('""', '"')
+        while "''" in text:
+            text = text.replace("''", "'")
+        while "``" in text:
+            text = text.replace("``", "`")
+        text = re.sub(r"\s+", " ", text).strip()
+        if not re.search(r"[.!?;:,'\"')\]}…。」』】〉》›»]$", text):
+            text += "."
+        if lang not in AVAILABLE_LANGS:
+            raise ValueError(f"Invalid language: {lang}")
+        return f"<{lang}>{text}</{lang}>"
+
+    def __call__(self, text_list: list[str], lang_list: list[str]) -> tuple[np.ndarray, np.ndarray]:
+        text_list = [self._preprocess_text(t, lang) for t, lang in zip(text_list, lang_list)]
+        lengths = np.array([len(text) for text in text_list], dtype=np.int64)
+        text_ids = np.zeros((len(text_list), lengths.max()), dtype=np.int64)
+        for i, text in enumerate(text_list):
+            ids = [self.indexer[ord(char)] for char in text]
+            text_ids[i, : len(ids)] = np.array(ids, dtype=np.int64)
+        return text_ids, length_to_mask(lengths)
+
+
+@dataclass
+class Style:
+    ttl: np.ndarray
+    dp: np.ndarray
+
+
+class SupertonicMLX:
+    def __init__(self, model_dir: str | Path):
+        self.model_dir = Path(model_dir)
+        with open(self.model_dir / "tts.json", encoding="utf-8") as f:
+            self.cfgs = json.load(f)
+        self.text_processor = UnicodeProcessor(self.model_dir / "unicode_indexer.json")
+        self.duration_predictor = self._load_graph("duration_predictor")
+        self.text_encoder = self._load_graph("text_encoder")
+        self.vector_estimator = self._load_graph("vector_estimator")
+        self.vocoder = self._load_graph("vocoder")
+        self.sample_rate = int(self.cfgs["ae"]["sample_rate"])
+        self.base_chunk_size = int(self.cfgs["ae"]["base_chunk_size"])
+        self.chunk_compress_factor = int(self.cfgs["ttl"]["chunk_compress_factor"])
+        self.ldim = int(self.cfgs["ttl"]["latent_dim"])
+
+    def _load_graph(self, name: str) -> MLXGraph:
+        return MLXGraph(self.model_dir / "graphs" / f"{name}.json", self.model_dir / "weights" / f"{name}.npz")
+
+    @classmethod
+    def from_pretrained(cls, model_dir: str | Path) -> "SupertonicMLX":
+        return cls(model_dir)
+
+    def load_voice_style(self, voice: str | Path | list[str | Path]) -> Style:
+        paths = [voice] if isinstance(voice, (str, Path)) else voice
+        first = json.load(open(paths[0], encoding="utf-8"))
+        ttl_dims = first["style_ttl"]["dims"]
+        dp_dims = first["style_dp"]["dims"]
+        ttl = np.zeros([len(paths), ttl_dims[1], ttl_dims[2]], dtype=np.float32)
+        dp = np.zeros([len(paths), dp_dims[1], dp_dims[2]], dtype=np.float32)
+        for i, path in enumerate(paths):
+            data = json.load(open(path, encoding="utf-8"))
+            ttl[i] = np.array(data["style_ttl"]["data"], dtype=np.float32).reshape(ttl_dims[1], ttl_dims[2])
+            dp[i] = np.array(data["style_dp"]["data"], dtype=np.float32).reshape(dp_dims[1], dp_dims[2])
+        return Style(ttl=ttl, dp=dp)
+
+    def get_voice_style(self, voice_name: str = "M1") -> Style:
+        return self.load_voice_style(self.model_dir / "voice_styles" / f"{voice_name}.json")
+
+    def sample_noisy_latent(self, duration: np.ndarray, seed: Optional[int] = None) -> tuple[np.ndarray, np.ndarray]:
+        rng = np.random.default_rng(seed)
+        bsz = len(duration)
+        wav_len_max = duration.max() * self.sample_rate
+        wav_lengths = (duration * self.sample_rate).astype(np.int64)
+        chunk_size = self.base_chunk_size * self.chunk_compress_factor
+        latent_len = ((wav_len_max + chunk_size - 1) / chunk_size).astype(np.int32)
+        latent_dim = self.ldim * self.chunk_compress_factor
+        noisy_latent = rng.standard_normal((bsz, latent_dim, latent_len)).astype(np.float32)
+        latent_mask = get_latent_mask(wav_lengths, self.base_chunk_size, self.chunk_compress_factor)
+        return noisy_latent * latent_mask, latent_mask
+
+    def _infer(
+        self,
+        text_list: list[str],
+        lang_list: list[str],
+        style: Style,
+        total_step: int,
+        speed: float = 1.05,
+        seed: Optional[int] = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        text_ids, text_mask = self.text_processor(text_list, lang_list)
+        dur = np.array(
+            self.duration_predictor(text_ids=text_ids, style_dp=style.dp, text_mask=text_mask)[0],
+            dtype=np.float32,
+        )
+        dur = dur / speed
+        text_emb = self.text_encoder(text_ids=text_ids, style_ttl=style.ttl, text_mask=text_mask)[0]
+        xt, latent_mask = self.sample_noisy_latent(dur, seed=seed)
+        bsz = len(text_list)
+        total_step_np = np.array([total_step] * bsz, dtype=np.float32)
+        for step in range(total_step):
+            current_step = np.array([step] * bsz, dtype=np.float32)
+            xt = self.vector_estimator(
+                noisy_latent=xt,
+                text_emb=text_emb,
+                style_ttl=style.ttl,
+                text_mask=text_mask,
+                latent_mask=latent_mask,
+                current_step=current_step,
+                total_step=total_step_np,
+            )[0]
+            mx.eval(xt)
+        wav = self.vocoder(latent=xt)[0]
+        return np.array(wav, dtype=np.float32), dur
+
+    def synthesize(
+        self,
+        text: str,
+        lang: str,
+        voice_style: Style,
+        total_step: int = 8,
+        speed: float = 1.05,
+        seed: Optional[int] = None,
+        silence_duration: float = 0.3,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if voice_style.ttl.shape[0] != 1:
+            raise ValueError("Single-text synthesis requires a single voice style")
+        max_len = 120 if lang in ("ko", "ja") else 300
+        wav_cat = None
+        dur_cat = None
+        for i, chunk in enumerate(chunk_text(text, max_len=max_len)):
+            wav, dur = self._infer([chunk], [lang], voice_style, total_step, speed, None if seed is None else seed + i)
+            if wav_cat is None:
+                wav_cat = wav
+                dur_cat = dur
+            else:
+                silence = np.zeros((1, int(silence_duration * self.sample_rate)), dtype=np.float32)
+                wav_cat = np.concatenate([wav_cat, silence, wav], axis=1)
+                dur_cat += dur + silence_duration
+        assert wav_cat is not None and dur_cat is not None
+        return wav_cat, dur_cat
+
+    def batch(
+        self,
+        text_list: list[str],
+        lang_list: list[str],
+        voice_style: Style,
+        total_step: int = 8,
+        speed: float = 1.05,
+        seed: Optional[int] = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        return self._infer(text_list, lang_list, voice_style, total_step, speed, seed)
+
+
+def length_to_mask(lengths: np.ndarray, max_len: Optional[int] = None) -> np.ndarray:
+    max_len = int(max_len or lengths.max())
+    ids = np.arange(0, max_len)
+    mask = (ids < np.expand_dims(lengths, axis=1)).astype(np.float32)
+    return mask.reshape(-1, 1, max_len)
+
+
+def get_latent_mask(wav_lengths: np.ndarray, base_chunk_size: int, chunk_compress_factor: int) -> np.ndarray:
+    latent_size = base_chunk_size * chunk_compress_factor
+    latent_lengths = (wav_lengths + latent_size - 1) // latent_size
+    return length_to_mask(latent_lengths)
+
+
+def chunk_text(text: str, max_len: int = 300) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n+", text.strip()) if p.strip()]
+    chunks = []
+    for paragraph in paragraphs:
+        pattern = r"(?<!Mr\.)(?<!Mrs\.)(?<!Ms\.)(?<!Dr\.)(?<!Prof\.)(?<!Sr\.)(?<!Jr\.)(?<!Ph\.D\.)(?<!etc\.)(?<!e\.g\.)(?<!i\.e\.)(?<!vs\.)(?<!Inc\.)(?<!Ltd\.)(?<!Co\.)(?<!Corp\.)(?<!St\.)(?<!Ave\.)(?<!Blvd\.)(?<!\b[A-Z]\.)(?<=[.!?])\s+"
+        current = ""
+        for sentence in re.split(pattern, paragraph):
+            if len(current) + len(sentence) + 1 <= max_len:
+                current += (" " if current else "") + sentence
+            else:
+                if current:
+                    chunks.append(current.strip())
+                current = sentence
+        if current:
+            chunks.append(current.strip())
+    return chunks or [text]
+
+
+@contextmanager
+def timer(label: str):
+    start = perf_counter()
+    yield
+    print(f"{label}: {perf_counter() - start:.3f}s")


### PR DESCRIPTION
Adds an experimental MLX graph runtime for Supertonic 3 by converting the published ONNX graphs into JSON topology plus NPZ initializers and executing the Supertonic-specific ONNX subset with MLX arrays.\n\nIncluded:\n- ONNX-to-MLX asset converter\n- MLX graph executor and TTS pipeline\n- inference, validation, and ONNX-vs-MLX comparison scripts\n- README usage notes\n\nValidation on the published Supertonic 3 assets shows per-stage max absolute differences around 1e-5 against ONNX Runtime.