### PR TITLE
add ci for supertonic docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,68 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runner: ubuntu-24.04
+          - platform: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build --platform linux/${{ matrix.platform }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.platform }} .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-${{ matrix.platform }}
+
+  create-manifest:
+    runs-on: ubuntu-24.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push Docker Manifest
+        run: |
+          IMAGE_NAME=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          MANIFEST_TAG=latest
+
+          docker manifest create \
+            $IMAGE_NAME:$MANIFEST_TAG \
+            --amend $IMAGE_NAME:latest-amd64 \
+            --amend $IMAGE_NAME:latest-arm64
+
+          docker manifest push $IMAGE_NAME:$MANIFEST_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+RUN pip install --no-cache-dir 'supertonic[serve]'
+RUN supertonic download
+EXPOSE 7788
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:7788/v1/health')" || exit 1
+CMD ["supertonic", "serve", "--host", "0.0.0.0", "--port", "7788"]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,39 @@ supertonic serve --host 127.0.0.1 --port 7788
 
 Once running, use the native `POST /v1/tts` endpoint or the OpenAI-compatible `POST /v1/audio/speech` endpoint. The server also exposes interactive OpenAPI docs at `http://127.0.0.1:7788/docs`. See the [supertonic-py serve guide](https://supertone-inc.github.io/supertonic-py/cli/serve/) for request examples, batch synthesis, and custom Voice Builder JSON import.
 
+### Docker
+
+Run Supertonic as a local HTTP server via Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+You can also build and run the Docker image manually:
+
+```bash
+docker build -t supertonic .
+docker run -d -p 7788:7788 supertonic
+```
+
+Or use the pre-built image from GitHub Container Registry:
+
+```bash
+docker run -d -p 7788:7788 ghcr.io/supertone-inc/supertonic
+```
+
+Generate speech by calling the local server:
+
+```bash
+curl --location 'http://localhost:7788/v1/tts' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "text": "Hello World",
+    "lang": "en",
+    "voice": "F4"
+  }' --output output.wav
+```
+
 ## Getting Started
 
 First, clone the repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  supertonic:
+    build:
+      context: .
+    ports:
+      - "7788:7788"
+    restart: unless-stopped


### PR DESCRIPTION
This pull request introduces Docker support for running the Supertonic server, including a `Dockerfile`, a `docker-compose.yml` for easy local orchestration, and Github Actions file forautomated publishing of the image to GitHub Container Registry. The documentation is also updated with clear instructions for using Docker and Docker Compose.

**Docker support and automation:**

* Added a `Dockerfile` that builds a minimal Python 3.11 image, installs Supertonic, downloads required models, sets up a healthcheck, and exposes the service on port 7788.
* Introduced a `docker-compose.yml` file for running Supertonic locally with Docker Compose, mapping port 7788 and enabling automatic restarts.
* Created a GitHub Actions workflow (`.github/workflows/docker-publish.yml`) to build and push multi-architecture Docker images (amd64, arm64) to GitHub Container Registry, and to create a Docker manifest for easy pulling.

**Documentation improvements:**

* Updated `README.md` with detailed instructions for running Supertonic using Docker Compose, building and running the Docker image manually, pulling the pre-built image, and making requests to the server.