### PR TITLE
docs(readme): add Readible App Store listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ Supertonic is designed to handle complex, real-world text inputs that contain na
 | **TLDRL** | Free, on-device TTS extension for reading any webpage | [Chrome](https://chromewebstore.google.com/detail/tldrl-lightning-tts-power/mdbiaajonlkomihpcaffhkagodbcgbme) |
 | **Read Aloud** | Open-source TTS browser extension | [Chrome](https://chromewebstore.google.com/detail/read-aloud-a-text-to-spee/hdhinadidafjejdhmfkjgnolgimiaplp) · [Edge](https://microsoftedge.microsoft.com/addons/detail/read-aloud-a-text-to-spe/pnfonnnmfjnpfgagnklfaccicnnjcdkm) · [GitHub](https://github.com/ken107/read-aloud) |
 | **PageEcho** | E-Book reader app for iOS | [App Store](https://apps.apple.com/us/app/pageecho/id6755965837) |
+| **Readible** | Reader app for web articles and EPUBs with offline Supertonic voices | [App Store](https://apps.apple.com/us/app/readible-listen-read/id6751535572) |
 | **VoiceChat** | On-device voice-to-voice LLM chatbot in the browser | [Demo](https://huggingface.co/spaces/RickRossTN/ai-voice-chat) · [GitHub](https://github.com/irelate-ai/voice-chat) |
 | **OmniAvatar** | Talking avatar video generator from photo + speech | [Demo](https://huggingface.co/spaces/alexnasa/OmniAvatar) |
 | **CopiloTTS** | Kotlin Multiplatform TTS SDK via ONNX Runtime | [GitHub](https://github.com/sigmadeltasoftware/CopiloTTS) |


### PR DESCRIPTION
## Summary

Adds Readible to the README's **Built with Supertonic** table as an App Store-backed community project entry.

The row now follows the same shape as PageEcho: a short product description plus a public App Store link.

## PageEcho comparison

- PageEcho was added in maintainer commit `3e495f8` (`add community projects`) when the **Built with Supertonic** section was introduced.
- That row uses a concise iOS app description and an App Store link only.
- This PR mirrors that pattern for Readible instead of linking to a generic website.

## Contribution notes

I checked the repository metadata and tree for contribution guidance. There is no `CONTRIBUTING.md`, PR template, issue template, or code of conduct in this repo, so this PR keeps the change scoped to the existing README table style.

## Validation

- README-only change: one row added to `README.md`.
- Verified the Readible App Store URL returns HTTP 200: https://apps.apple.com/us/app/readible-listen-read/id6751535572
- Verified the App Store listing identifies `Readible: Listen & Read` by Ankur Mittal and mentions offline/on-device voice improvements.